### PR TITLE
Add Dremio. Fixes #13

### DIFF
--- a/base-notebook/cpu/Dockerfile
+++ b/base-notebook/cpu/Dockerfile
@@ -9,6 +9,20 @@ RUN pip --no-cache-dir install  --quiet \
       'git+https://github.com/kubeflow/fairing@b1065c68f93b13389b19a21a17c8ca3d60fa75b7' \
       'minio'
 
+# Added ODBC Support for Dremio
+RUN conda install --quiet --yes pyodbc && \
+    apt-get update && \
+    apt-get install -y alien unixodbc unixodbc-dev && \
+    wget http://download.dremio.com/odbc-driver/dremio-odbc-LATEST.x86_64.rpm && \
+    alien -i --scripts dremio-odbc-*x86_64.rpm && \
+    rm -f dremio-odbc-*x86_64.rpm && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force && \
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    rm -rf /home/$NB_USER/.node-gyp && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
+
 # Configure container startup
 EXPOSE 8888
 USER jovyan

--- a/base-notebook/cpu/Dockerfile
+++ b/base-notebook/cpu/Dockerfile
@@ -23,6 +23,9 @@ RUN conda install --quiet --yes pyodbc && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# Need this to connect
+ENV DREMIO_DRIVER=/opt/dremio-odbc/lib64/libdrillodbc_sb64.so
+
 # Configure container startup
 EXPOSE 8888
 USER jovyan

--- a/base-notebook/gpu/Dockerfile
+++ b/base-notebook/gpu/Dockerfile
@@ -370,6 +370,22 @@ RUN pip --no-cache-dir install  --quiet \
       'git+https://github.com/kubeflow/fairing@b1065c68f93b13389b19a21a17c8ca3d60fa75b7' \
       'minio'
 
+
+# Added ODBC Support for Dremio
+RUN conda install --quiet --yes pyodbc && \
+    apt-get update && \
+    apt-get install -y alien unixodbc unixodbc-dev && \
+    wget http://download.dremio.com/odbc-driver/dremio-odbc-LATEST.x86_64.rpm && \
+    alien -i --scripts dremio-odbc-*x86_64.rpm && \
+    rm -f dremio-odbc-*x86_64.rpm && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force && \
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    rm -rf /home/$NB_USER/.node-gyp && \
+    fix-permissions $CONDA_DIR && \
+    fix-permissions /home/$NB_USER
+
+
 # Configure container startup
 EXPOSE 8888
 USER jovyan

--- a/base-notebook/gpu/Dockerfile
+++ b/base-notebook/gpu/Dockerfile
@@ -385,6 +385,8 @@ RUN conda install --quiet --yes pyodbc && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
+# Need this to connect
+ENV DREMIO_DRIVER=/opt/dremio-odbc/lib64/libdrillodbc_sb64.so
 
 # Configure container startup
 EXPOSE 8888


### PR DESCRIPTION
Built this on the cpu base image. My computer will probably crash if I try to compile the GPU Image but I'm assuming that it'll play nice. **I haven't successfully connected via python!** The following should test connectivity

```
from getpass import getpass
import pyodbc

host = 'dremio.covid.cloud.statcan.ca'
port = 31010
driver = '/opt/dremio-odbc/lib64/libdrillodbc_sb64.so'
cnxn = pyodbc.connect(';'.join([
    f"Driver={driver}", 
    "ConnectionType=Direct;",
    f"HOST={host}",
    f"PORT={port}",
    "AuthenticationType=Plain",
    "UID={}".format(getpass('Dremio Username: ')),
    "PWD={}".format(getpass('Dremio Password: '))]),
    autocommit=True
)
```

However from my machine **this command hangs**. It might be different if run inside the cluster?