### PR TITLE
fix: remove --allow-root option

### DIFF
--- a/base-notebook/cpu/start-custom.sh
+++ b/base-notebook/cpu/start-custom.sh
@@ -9,7 +9,6 @@ git clone https://github.com/statcan/jupyter-notebooks
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
-                 --allow-root \
                  --port=8888 \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \

--- a/base-notebook/gpu/start-custom.sh
+++ b/base-notebook/gpu/start-custom.sh
@@ -9,7 +9,6 @@ git clone https://github.com/statcan/jupyter-notebooks
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \
-                 --allow-root \
                  --port=8888 \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \


### PR DESCRIPTION
Closes #31 . This --allow-root option seems unnecessary, as we don't
run as root, and the option only seems to be suggested for the that
case.

See https://github.com/kubeflow/kubeflow/issues/300 too.