### PR TITLE
fix(r-studio): fix libssl error in new version (rollback)

### DIFF
--- a/base-notebook/cpu/Dockerfile
+++ b/base-notebook/cpu/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/jupyter/docker-stacks/blob/master/datascience-notebook/Dockerfile
-FROM jupyter/datascience-notebook
+FROM jupyter/datascience-notebook:04f7f60d34a6 
 USER root
 ENV PATH="/home/jovyan/.local/bin:${PATH}"
 

--- a/r-studio/Dockerfile
+++ b/r-studio/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/r-notebook
+FROM jupyter/r-notebook:c094bb7219f9
 USER root
 
 # install rstudio-server


### PR DESCRIPTION
Error with libssl seems to be a new one. For now just pinning to an older version (like 2 weeks old) and can investigate further from there.

Pinned the base/cpu image while I was at it.