### PR TITLE
feat(geomatics-notebook): add postal

### DIFF
--- a/geomatics-notebook/cpu/Dockerfile
+++ b/geomatics-notebook/cpu/Dockerfile
@@ -5,6 +5,7 @@ RUN conda install --quiet --yes \
       'fiona' \
       'gdal' \
       'geopandas' \
+      'postal' \
       'rasterio' \
       'r-classInt' \
       'r-deldir' \


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/63

Adds conda package `postal`, which pulls in PyPostal as well as LibPostal (through dependency conda package libpostal). Increases the image size by 2GB, from 11.6GB to 13.6GB. If this is too much relative to how frequently these libraries are needed, then individual users are free to instead independently install this via `conda install postal` in the terminals of their containers.

Note that for the tests described in https://github.com/openvenues/pypostal to succeed, setup.py must be modified: 
1. Replace all instances of `include_dirs=['/usr/local/include']` with `include_dirs=['/opt/conda/include']`
1. Replace all instances of `library_dirs=['/usr/local/lib']` with `library_dirs=['/opt/conda/lib']`

These modifications may be relevant for other code, but I figure they are a standard concern given that this is a conda-based environment.