### PR TITLE
feat(notebooks): cell execution information

### DIFF
--- a/minimal-notebook/cpu/Dockerfile
+++ b/minimal-notebook/cpu/Dockerfile
@@ -104,10 +104,15 @@ RUN pip install --quiet \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
 
+#Enable cell execution time
+RUN mkdir -p /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/notebook-extension && \
+  echo '{"recordTiming": true }' > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/notebook-extension/tracker.jupyterlab-settings && \
+  fix-permissions /home/$NB_USER
+
+
 # Solarized
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension && \
-  printf '{ "theme": "JupyterLab Solarized Dark" }\n' && \
-  > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings && \
+  echo '{ "theme": "JupyterLab Solarized Dark" }' > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings && \
   fix-permissions /home/$NB_USER
 
 # Go

--- a/minimal-notebook/gpu/Dockerfile
+++ b/minimal-notebook/gpu/Dockerfile
@@ -105,10 +105,14 @@ RUN pip install --quiet \
   fix-permissions $CONDA_DIR && \
   fix-permissions /home/$NB_USER
 
+# Enable cell execution time
+RUN mkdir -p /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/notebook-extension && \
+  echo '{"recordTiming": true }' > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/notebook-extension/tracker.jupyterlab-settings && \
+  fix-permissions /home/$NB_USER
+
 # Solarized
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension && \
-  printf '{ "theme": "JupyterLab Solarized Dark" }\n' && \
-  > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings && \
+  echo '{ "theme": "JupyterLab Solarized Dark" }' > /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab/apputils-extension/themes.jupyterlab-settings && \
   fix-permissions /home/$NB_USER
 
 # Go


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/39

Enabled the extension to display cell execution information in `minimal-notebook-cpu` and `minimal-notebook-gpu`. Also noticed that there was an attempt to use the solarized dark theme in the dockerfiles for the notebooks but it wasn't being implemented correctly so I corrected that too.

I tried to do these changes by using the other `overrides.json` method as explained in [the developer guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_dev.html#storing-extension-data) but that wasn't working so I did it in the other method using `@jupyterlab/notebook-extension/tracker.jupyterlab-settings`. 