### PR TITLE
Pin Git Extension Versions (v0.20.0)

### DIFF
--- a/minimal-notebook/cpu/Dockerfile
+++ b/minimal-notebook/cpu/Dockerfile
@@ -64,7 +64,7 @@ RUN pip install --quiet \
       'ipympl' \
       'jupyter_contrib_nbextensions' \
       'jupyterlab-dash' \
-      'jupyterlab-git' \
+      'jupyterlab-git==0.20.0' \
       'xeus-python' \
       'nodejs' \
       'python-language-server' \
@@ -87,7 +87,7 @@ RUN pip install --quiet \
       '@lckr/jupyterlab_variableinspector' \
       '@jupyterlab/debugger' \
       '@jupyterlab/github' \
-      '@jupyterlab/git' \
+      '@jupyterlab/git@0.20.0' \
       '@jupyterlab/toc' \
       'jupyter-matplotlib' \
       'jupyterlab-execute-time' \

--- a/minimal-notebook/gpu/Dockerfile
+++ b/minimal-notebook/gpu/Dockerfile
@@ -65,7 +65,7 @@ RUN pip install --quiet \
       'ipympl' \
       'jupyter_contrib_nbextensions' \
       'jupyterlab-dash' \
-      'jupyterlab-git' \
+      'jupyterlab-git==0.20.0' \
       'xeus-python' \
       'nodejs' \
       'python-language-server' \
@@ -88,7 +88,7 @@ RUN pip install --quiet \
       '@lckr/jupyterlab_variableinspector' \
       '@jupyterlab/debugger' \
       '@jupyterlab/github' \
-      '@jupyterlab/git' \
+      '@jupyterlab/git@0.20.0' \
       '@jupyterlab/toc' \
       'jupyter-matplotlib' \
       'jupyterlab-execute-time' \


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/93

Pinned v0.20.0 to the JupyterLab git server and lab extensions in `minimal-notebook-cpu` and `minimal-notebook-gpu`.
