### PR TITLE
update: jupyterlab-dash to jupyter-dash

### DIFF
--- a/minimal-notebook/cpu/Dockerfile
+++ b/minimal-notebook/cpu/Dockerfile
@@ -43,12 +43,12 @@ RUN curl -LO "${KUBECTL_URL}" \
 # Default environment
 RUN pip install --quiet \
       'jupyter-lsp==0.9.2' \
+      'jupyter-server-proxy==1.5.0' \
     && \
     conda install --quiet --yes \
     -c conda-forge \
       'ipympl==0.5.8' \
       'jupyter_contrib_nbextensions==0.5.1' \
-      'jupyterlab-dash==0.1.0a3' \
       'jupyterlab-git==0.20.0' \
       'xeus-python==0.8.4' \
       'nodejs==13.13.0' \
@@ -59,6 +59,10 @@ RUN pip install --quiet \
       'r-tidyr==1.1.2' \
       'r-jsonlite==1.7.1' \
       'r-rstan==2.21.2' \
+    && \
+    conda install --quiet --yes \
+      -c plotly \
+      'jupyter-dash==0.3.0' \
     && \
     conda clean --all -f -y && \
     jupyter nbextension enable codefolding/main --sys-prefix && \

--- a/minimal-notebook/gpu/Dockerfile
+++ b/minimal-notebook/gpu/Dockerfile
@@ -46,6 +46,7 @@ RUN pip install --quiet \
       'gpustat==0.6.0' \
       'kubernetes==11.0.0' \
       'jupyter-lsp==0.9.1' \
+      'jupyter-server-proxy==1.5.0' \
     && \
     conda install --quiet --yes \
       'jupyterlab>=2.2.2' \
@@ -55,7 +56,6 @@ RUN pip install --quiet \
       'ipywidgets==7.5.1' \
       'ipympl==0.5.8' \
       'jupyter_contrib_nbextensions==0.5.1' \
-      'jupyterlab-dash==0.1.0a3' \
       'jupyterlab-git==0.20.0' \
       'xeus-python==0.8.4' \
       'nodejs==12.18.3' \
@@ -68,6 +68,10 @@ RUN pip install --quiet \
       'r-jsonlite==1.7.1' \
       'r-ggplot2==3.3.2' \
       'r-rstan==2.21.2' \
+    && \
+    conda install --quiet --yes \
+     -c plotly \
+     'jupyter-dash==0.3.0' \
     && \
     conda clean --all -f -y && \
     jupyter nbextension enable codefolding/main --sys-prefix && \


### PR DESCRIPTION
Resolves #127 
Jupyterlab-dash is no longer maintained
Needs jupyter-server-proxy.
- Returns connection refused without it