### PR TITLE
chore: update tensorflow version

### DIFF
--- a/machine-learning-notebook/cpu/Dockerfile
+++ b/machine-learning-notebook/cpu/Dockerfile
@@ -2,12 +2,10 @@ FROM k8scc01covidacr.azurecr.io/minimal-notebook-cpu:master
 USER root
 
 # Install Tensorflow
-RUN conda config --set channel_priority false && \
-    conda install --quiet --yes \
-      'tensorflow==2.2.0' \
-      'keras==2.4.3' \
+RUN pip --no-cache-dir install --quiet \
+     'tensorflow==2.3.1' \
+     'keras==2.4.3' \
     && \
-    conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 


### PR DESCRIPTION
Resolves https://github.com/StatCan/kubeflow-containers/issues/138
- Updated tensorflow to version 2.3.1
- Latest version of tensorflow using `conda install` is 2.2.0, so switched to `pip` to get latest version (2.3.1)