### PR TITLE
Test output synced

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,10 +41,18 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: Test output folder
+      run: |
+        sudo apt-get install --yes make
+        make all
+        if ! git diff --quiet output/; then
+            echo 'output folder and docker-bits/resources out of sync!'
+            exit 1
+        fi
+
     # Container build and push to a Azure Container registry (ACR)
     - name: Build image
       run: |
-        sudo apt-get install --yes make
         make all
         COMMIT=$(make get-commit)
         echo

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -46,6 +46,15 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: Test output folder
+      run: |
+        sudo apt-get install --yes make
+        make all
+        if ! git diff --quiet output/; then
+            echo 'output folder and docker-bits/resources out of sync!'
+            exit 1
+        fi
+
     # Connect to Azure Container registry (ACR)
     - uses: azure/docker-login@v1
       with:
@@ -56,7 +65,6 @@ jobs:
     # Container build and push to a Azure Container registry (ACR)
     - name: Build image
       run: |
-        sudo apt-get install --yes make
         make all
         COMMIT=$(make get-commit)
         echo

--- a/output/RStudio/start-custom.sh
+++ b/output/RStudio/start-custom.sh
@@ -21,8 +21,6 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.zsh-installed
 fi
 
-
-
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \

--- a/output/RStudio/start-custom.sh
+++ b/output/RStudio/start-custom.sh
@@ -21,6 +21,8 @@ if [ ! -f /home/$NB_USER/.zsh-installed ]; then
     touch /home/$NB_USER/.zsh-installed
 fi
 
+
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \


### PR DESCRIPTION
This adds a step in the workflow to check that `output` is in-sync with `make all`. (I.e. make sure that no one edited output directly)

Commit 3f515aa shows that it works.


**NOTE: This should be squash-merged**