### PR TITLE
feat(rstudio): upgrade rstudio to 1.4

### DIFF
--- a/docker-bits/6_RStudio.Dockerfile
+++ b/docker-bits/6_RStudio.Dockerfile
@@ -1,10 +1,8 @@
 # install rstudio-server
-ARG RSTUDIO_VERSION=1.1.463
-ARG SHA256=62aafd46f79705ca5db9c629ce3b60bf708d81c06a6b86cc4b417fbaf30691c1
+ARG RSTUDIO_VERSION=1.4.1103
+ARG SHA256=552baf1bbfd98fc36a3f63c430cce3ceb16dd41de723a535fa27d254ff6afa62
 RUN apt-get update && \
-    wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.5_amd64.deb -O libssl1.0.0.deb && \
-    dpkg -i libssl1.0.0.deb && \
-    curl --silent -L --fail "https://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb && \
+    curl --silent -L  --fail "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb && \
     echo "${SHA256} /tmp/rstudio.deb" | sha256sum -c - && \
     apt-get install --no-install-recommends -y /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb && \
@@ -12,10 +10,7 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 
 # Install some default R packages
-RUN python3 -m pip install \
-      'jupyter-rsession-proxy==1.2' \
-      'jupyter-shiny-proxy==1.1' && \
-    conda install --quiet --yes \
+RUN conda install --quiet --yes \
       'r-rodbc==1.3_16' \
       'r-tidymodels==0.1.2' \
       'r-arrow==2.0.0' \
@@ -29,6 +24,12 @@ RUN python3 -m pip install \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
+
+RUN python3 -m pip install \
+      'git+git://github.com/blairdrummond/jupyter-rsession-proxy#egg=jupyter-rsession-proxy' \
+      'jupyter-shiny-proxy==1.1'
+
+RUN chown $NB_USER:users /var/lib/rstudio-server/rstudio.sqlite
 
 ENV DEFAULT_JUPYTER_URL="/rstudio"
 ENV GIT_EXAMPLE_NOTEBOOKS=https://github.com/statcan/R-notebooks.git

--- a/output/JupyterLab-CPU/start-custom.sh
+++ b/output/JupyterLab-CPU/start-custom.sh
@@ -39,6 +39,11 @@ cat <<EOF > $HOME/.config/kfp/context.json
 EOF
 fi
 
+# Introduced by RStudio 1.4
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95
+# And https://github.com/blairdrummond/jupyter-rsession-proxy/blob/master/jupyter_rsession_proxy/__init__.py
+export RSERVER_WWW_ROOT_PATH=$NB_PREFIX/rstudio
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \

--- a/output/JupyterLab-PyTorch/start-custom.sh
+++ b/output/JupyterLab-PyTorch/start-custom.sh
@@ -39,6 +39,11 @@ cat <<EOF > $HOME/.config/kfp/context.json
 EOF
 fi
 
+# Introduced by RStudio 1.4
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95
+# And https://github.com/blairdrummond/jupyter-rsession-proxy/blob/master/jupyter_rsession_proxy/__init__.py
+export RSERVER_WWW_ROOT_PATH=$NB_PREFIX/rstudio
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \

--- a/output/JupyterLab-Tensorflow/start-custom.sh
+++ b/output/JupyterLab-Tensorflow/start-custom.sh
@@ -39,6 +39,11 @@ cat <<EOF > $HOME/.config/kfp/context.json
 EOF
 fi
 
+# Introduced by RStudio 1.4
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95
+# And https://github.com/blairdrummond/jupyter-rsession-proxy/blob/master/jupyter_rsession_proxy/__init__.py
+export RSERVER_WWW_ROOT_PATH=$NB_PREFIX/rstudio
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \

--- a/output/RStudio/Dockerfile
+++ b/output/RStudio/Dockerfile
@@ -115,12 +115,10 @@ RUN apt-get update && \
 ###############################
 
 # install rstudio-server
-ARG RSTUDIO_VERSION=1.1.463
-ARG SHA256=62aafd46f79705ca5db9c629ce3b60bf708d81c06a6b86cc4b417fbaf30691c1
+ARG RSTUDIO_VERSION=1.4.1103
+ARG SHA256=552baf1bbfd98fc36a3f63c430cce3ceb16dd41de723a535fa27d254ff6afa62
 RUN apt-get update && \
-    wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.5_amd64.deb -O libssl1.0.0.deb && \
-    dpkg -i libssl1.0.0.deb && \
-    curl --silent -L --fail "https://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb && \
+    curl --silent -L  --fail "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb && \
     echo "${SHA256} /tmp/rstudio.deb" | sha256sum -c - && \
     apt-get install --no-install-recommends -y /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb && \
@@ -128,10 +126,7 @@ RUN apt-get update && \
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 
 # Install some default R packages
-RUN python3 -m pip install \
-      'jupyter-rsession-proxy==1.2' \
-      'jupyter-shiny-proxy==1.1' && \
-    conda install --quiet --yes \
+RUN conda install --quiet --yes \
       'r-rodbc==1.3_16' \
       'r-tidymodels==0.1.2' \
       'r-arrow==2.0.0' \
@@ -145,6 +140,12 @@ RUN python3 -m pip install \
     conda clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
+
+RUN python3 -m pip install \
+      'git+git://github.com/blairdrummond/jupyter-rsession-proxy#egg=jupyter-rsession-proxy' \
+      'jupyter-shiny-proxy==1.1'
+
+RUN chown $NB_USER:users /var/lib/rstudio-server/rstudio.sqlite
 
 ENV DEFAULT_JUPYTER_URL="/rstudio"
 ENV GIT_EXAMPLE_NOTEBOOKS=https://github.com/statcan/R-notebooks.git

--- a/output/RStudio/start-custom.sh
+++ b/output/RStudio/start-custom.sh
@@ -39,6 +39,11 @@ cat <<EOF > $HOME/.config/kfp/context.json
 EOF
 fi
 
+# Introduced by RStudio 1.4
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95
+# And https://github.com/blairdrummond/jupyter-rsession-proxy/blob/master/jupyter_rsession_proxy/__init__.py
+export RSERVER_WWW_ROOT_PATH=$NB_PREFIX/rstudio
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \

--- a/resources/start-custom.sh
+++ b/resources/start-custom.sh
@@ -39,6 +39,11 @@ cat <<EOF > $HOME/.config/kfp/context.json
 EOF
 fi
 
+# Introduced by RStudio 1.4
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95
+# And https://github.com/blairdrummond/jupyter-rsession-proxy/blob/master/jupyter_rsession_proxy/__init__.py
+export RSERVER_WWW_ROOT_PATH=$NB_PREFIX/rstudio
+
 jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --ip=0.0.0.0 \
                  --no-browser \


### PR DESCRIPTION
This was more complicated than expected! It also adds a [fork of rsession-proxy](https://github.com/blairdrummond/jupyter-rsession-proxy)

# SQLite permission change (chown)

First error encountered was a sqlite error not being able to write to a database. The issue seems to have been a simple ownership issue. `/var/lib/rstudio-server/rstudio.sqlite` is owned by `rstudio-server`, but when we start rstudio via jupyter, the running user is `jovyan`. So needed to add:

```
chown $NB_USER:users /var/lib/rstudio-server/rstudio.sqlite
```

And *also* need rserver to use the jovyan user, which leads to [this proxy change](https://github.com/blairdrummond/jupyter-rsession-proxy/blob/eb5c4b7023f82ab7841d55fef54c56ebe7a51705/jupyter_rsession_proxy/__init__.py#L38).

# auth-none=1 and www-root-path

This is just a new setting introduced by [this PR](https://github.com/rstudio/rstudio/pull/7628#issuecomment-723190694). Basically ALL rstudio auth mechanisms send you to an auth page, but if auth is none then you proceed immediately... However, since we run on `/rstudio` not `/`, we have to configure the www-root-path or else auth redirects to a non-existent path.

So that's where we get [the proxy changes](https://github.com/blairdrummond/jupyter-rsession-proxy/blob/9faa6d5114b280bf80846c3841a58d78e17d1494/jupyter_rsession_proxy/__init__.py#L34-L45)

**There is discussion of this on [this rsession-proxy issue](https://github.com/jupyterhub/jupyter-rsession-proxy/issues/95#issuecomment-766412024)**

## Viola
![Screenshot from 2021-01-24 13-52-50](https://user-images.githubusercontent.com/10801138/105640404-d2600b80-5e4b-11eb-8da5-76775d9a6455.png)

