### PR TITLE
Add deploy triggers

### DIFF
--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -1,6 +1,6 @@
-# This workflow will build a docker container, publish it to Azure Container Registry, and deploy it to Azure Kubernetes Service using a helm chart.
+# This workflow will build a docker container and publish it to Azure Container Registry
 #
-# https://github.com/Azure/actions-workflow-samples/tree/master/Kubernetes
+# Based on https://github.com/Azure/actions-workflow-samples/tree/master/Kubernetes
 #
 # To configure this workflow:
 #
@@ -9,7 +9,7 @@
 #     b. REGISTRY_PASSWORD with ACR Password
 #     c. AZURE_CREDENTIALS with the output of `az ad sp create-for-rbac --sdk-auth`
 #
-# 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below).
+# 2. Change the values for the REGISTRY
 
 # DEBUG: This is a temporary CI for testing.  This will be merged into push.yaml when complete, but must be tested on master branch (comment triggers only work on master)
 name: push on comment
@@ -25,9 +25,6 @@ on:
 # Environment variables available to all jobs and steps in this workflow
 env:
   REGISTRY: k8scc01covidacr.azurecr.io
-  REGISTRY_NAME: k8scc01covidacr
-  CLUSTER_NAME: k8s-cancentral-01-covid-aks
-  CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
 jobs:
   # Do initial tests to see if we should run (push or an issue_comment on a PR) or if we should ignore (an issue_comment NOT on a PR)
   # Inspired by https://stackoverflow.com/a/61832535/5394584
@@ -62,6 +59,28 @@ jobs:
             # Return null if false
         fi
 
+  notify-start:
+    # Notify of triggered start before build-push.  If done in build-push, this triggers
+    # once per matrix run
+    needs:
+      trigger-context
+    if: needs.trigger-context.outputs.in_scope == 'true'  # Could also just be if in_scope, as it'll be empty if false
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify start via comment
+      if: needs.trigger-context.outputs.is_pr_comment
+      id: notify-start
+      uses: actions/github-script@v1
+      with: 
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Build activated.  Track in [Github Actions](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/).  I will report back when things are pushed!`
+          })
+
   build-push:
     needs:
       trigger-context
@@ -71,11 +90,10 @@ jobs:
       matrix:
         notebook:
           - JupyterLab-CPU
-          # DEBUG images removed during debugging
-          # - JupyterLab-PyTorch
-          # - JupyterLab-Tensorflow
-          # - RStudio
-          # - JupyterLab-CPU-OL-compliant     
+          - JupyterLab-PyTorch
+          - JupyterLab-Tensorflow
+          - RStudio
+          - JupyterLab-CPU-OL-compliant     
     runs-on: ubuntu-latest
     services:
       registry:
@@ -100,22 +118,49 @@ jobs:
     - uses: ca-scribner/github-actions-recipes/get-event-ref-on-pr@24abb2d699ce6c7f8374404e4ccc7bd453bdf81a
       id: event_ref
     - uses: actions/checkout@master
-    
+
+    # Depending on whether this is a push or a pr-comment, branch name is discoverable differently.
+    - name: Report BRANCH_NAME env variable
+      id: report-branch-name
+      shell: bash
+      run: |
+        if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
+          # Use Github API to get branch name from PR details
+          OWNER=${{ github.event.repository.owner.login }}
+          REPOSITORY=${{ github.event.repository.name }}
+          PR_NUMBER=${{ needs.trigger-context.outputs.pr_number }}
+          BRANCH_NAME=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$OWNER/$REPOSITORY/pulls/$PR_NUMBER | jq '.head.ref')
+          # Remove leading/trailing quotes
+          BRANCH_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$BRANCH_NAME")
+        else
+          # Extract branch name from Github context's ref variable
+          BRANCH_NAME=${GITHUB_REF#refs/*/}
+        fi
+        echo "Found BRANCH_NAME=$BRANCH_NAME"
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
     # Extra checkout step to ensure we checkout PR's code when this triggers on PR comment
     # Without this, we will always check out master
-    - name: Checkout PR code
-      if: github.event_name == 'issue_comment'
+    - name: Checkout this Branch and update GITHUB_SHA if PR Comment
+      if: needs.trigger-context.outputs.is_pr_comment
       run: |
-         git fetch origin ${{ steps.event_ref.outputs.event_ref }}
-         git checkout FETCH_HEAD
+        git fetch origin
+        git checkout $BRANCH_NAME
+        BRANCH_SHA=$(git rev-parse $BRANCH_NAME)
+        echo "Updating GITHUB_SHA to $BRANCH_SHA"
+        echo "GITHUB_SHA=$BRANCH_SHA" >> $GITHUB_ENV  # This sets env.GITHUB_SHA for future steps, but wont overwrite $GITHUB_SHA in future steps(?!)
+        echo "BRANCH_SHA=$BRANCH_SHA" >> $GITHUB_ENV
 
-      # DEBUG Does GITHUB_SHA work for issue_comment?
-    - name: Add SHORT_SHA env property with commit short sha
+    - name: Report SHORT_SHA env variable
       run:  |
-        echo "SHORT_SHA=${GITHUB_SHA}"
-        echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        # Use env.GITHUB_SHA in case this was overwritten above.  For some reason $GITHUB_SHA is not updated
+        FULL_SHA=${{ env.GITHUB_SHA }}
+        echo "FULL_SHA=$FULL_SHA"
+        SHORT_SHA=`echo ${FULL_SHA} | cut -c1-8`
+        echo "SHORT_SHA=$SHORT_SHA"
+        echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
 
-    - name: Test output folder
+    - name: Assert committed ./output folder matches `make all` output
       run: |
         sudo apt-get install --yes make
         make all
@@ -130,24 +175,6 @@ jobs:
         login-server: ${{ env.REGISTRY_NAME }}.azurecr.io
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-
-    # Get branch name for tagging. 
-    # Depending on whether this is a push or a pr-comment, branch name is discoverable differently.
-    - name: Report branch name on PR comment
-      id: report-branch-name
-      shell: bash
-      run: |
-        if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
-          # Use Github API to get branch name from PR details
-          OWNER=${{ github.event.repository.owner.login }}
-          REPOSITORY=${{ github.event.repository.name }}
-          PR_NUMBER=${{ needs.trigger-context.outputs.pr_number }}
-          BRANCH_NAME=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$OWNER/$REPOSITORY/pulls/$PR_NUMBER | jq '.head.ref')
-        else
-          # Extract branch name from Github context's ref variable
-          BRANCH_NAME=${GITHUB_REF#refs/*/}
-        fi
-        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
     # Container build and push to a Azure Container registry (ACR)
     - name: Build image
@@ -172,33 +199,46 @@ jobs:
     # Container push to a Azure Container registry (ACR)
     - name: Push image
       id: push-image
+      shell: bash
       run: |
-        echo Repull the image
-        docker pull localhost:5000/kubeflow-image:$SHORT_SHA
-        docker tag localhost:5000/kubeflow-image:$SHORT_SHA kubeflow-image
+        SOURCE_IMAGE_NAME=localhost:5000/kubeflow-image:$SHORT_SHA
+        echo "Pull the image from local storage repo $SOURCE_IMAGE_NAME"
+        docker pull $SOURCE_IMAGE_NAME
 
-        echo
-        IMAGE_NAME="$(echo ${{ matrix.notebook }} | tr '[:upper:]' '[:lower:]')"
-        REGISTRY=${{ env.REGISTRY }}
+        IMAGE_NAME="${{ matrix.notebook }}"
 
-        echo
-        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$SHORT_SHA
-        docker push $REGISTRY/$IMAGE_NAME:$SHORT_SHA
-        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$BRANCH_NAME
-        docker push $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}  # I think this breaks for PR comments
-
-        if ["$BRANCH_NAME" == "master"]; then
-          docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:latest
-        docker push $REGISTRY/$IMAGE_NAME:latest
+        echo "Build tags list"
+        TAGS=($SHORT_SHA $BRANCH_NAME)
+        if [ "$BRANCH_NAME" == "master" ]; then
+            TAGS+=(latest)
         fi
+        echo "Tags to push: ${TAGS[@]}"
+
+        sanitize () {
+            # This:
+            # * removes leading non-alphanumeric/underscore characters
+            # * converts all non-alphanumeric/period/hyphen/underscore to hyphens
+            # * converts all characters to lowercase
+            local result="$(echo $1 | sed -e 's/^[^[:alnum:]\_]*//' -e 's/[^[:alnum:]\.\_\-]/-/g' | tr '[:upper:]' '[:lower:]')"
+            echo "$result"
+        }
+
+        echo
+        echo "Pushing tagged images"
+        PUSHED_IMAGES=()
+        for tag in "${TAGS[@]}"; do
+            TARGET_FULL_IMAGE_NAME="$(sanitize $REGISTRY)/$(sanitize $IMAGE_NAME):$(sanitize $tag)"
+            echo "Pushing docker image: $TARGET_FULL_IMAGE_NAME"
+            docker tag $SOURCE_IMAGE_NAME $TARGET_FULL_IMAGE_NAME
+            docker push $TARGET_FULL_IMAGE_NAME
+            PUSHED_IMAGES+=($TARGET_FULL_IMAGE_NAME)
+        done
 
         # Report
         echo
-        echo "Pushed $REGISTRY/$IMAGE_NAME:$SHORT_SHA"
-        echo "       $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}"
-        if ["$BRANCH_NAME" == "master"]; then
-          echo "       $REGISTRY/$IMAGE_NAME:latest"
-        fi
+        for pushed_image in "${PUSHED_IMAGES[@]}"; do
+            echo "Pushed $pushed_image"
+        done
 
     # This notification uses a semi-hardcoded image name.  There's probably a better way
     - name: Notify end via comment

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -153,25 +153,55 @@ jobs:
         severity-threshold: CRITICAL
         run-quality-checks: false
 
+    # Get branch name for tagging. 
+    # When triggered by a comment on a PR, ref points to master rather than true branch name
+    - name: Get branch name on PR comment
+      id: get-branch-name
+      if: needs.trigger-context.outputs.is_pr_comment
+      with: 
+        owner: ${{ github.event.repository.owner.login }}
+        repository: ${{ github.event.repository.name }}
+        pr_number: ${{ needs.trigger-context.outputs.pr_number }}
+      uses: ca-scribner/github-actions-recipes/get-branch-name-of-pr@fb78f53adf9877c3916e63b44cfb4132b9cdf4b7
+
+    - name: Report branch name on PR comment
+      id: report-branch-name
+      run: 
+        if [ "${{ needs.trigger-context.outputs.is_pr_comment }} == "true" ]; then
+          BRANCH_NAME=${{ steps.get-branch-name.outputs.branch }}
+        else
+          BRANCH_NAME=${GITHUB_REF#refs/*/}
+        fi
+        echo "BRANCH_NAME=$(echo $BRANCH_NAME | cut -c 1-6)" >> $GITHUB_ENV
+
     # Container push to a Azure Container registry (ACR)
     - name: Push image
       run: |
         echo Repull the image
         docker pull localhost:5000/kubeflow-image:$SHORT_SHA
         docker tag localhost:5000/kubeflow-image:$SHORT_SHA kubeflow-image
+
         echo
         IMAGE_NAME="$(echo ${{ matrix.notebook }} | tr '[:upper:]' '[:lower:]')"
         REGISTRY=${{ env.REGISTRY }}
+
         echo
         docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$SHORT_SHA
-        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}
-        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:latest
-        echo
-        # DEBUG: Removed during debugging
         # docker push $REGISTRY/$IMAGE_NAME:$SHORT_SHA
+        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$BRANCH_NAME
+        # DEBUG: Removed during debugging
         # docker push $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}  # I think this breaks for PR comments
+
+        if ["$BRANCH_NAME" == "master"]; then
+        # DEBUG: Removed during debugging
+          docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:latest
         # docker push $REGISTRY/$IMAGE_NAME:latest
+        fi
+
+        # Report
         echo
         echo "Pushed $REGISTRY/$IMAGE_NAME:$SHORT_SHA"
         echo "       $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}"
-        echo "       $REGISTRY/$IMAGE_NAME:latest"
+        if ["$BRANCH_NAME" == "master"]; then
+          echo "       $REGISTRY/$IMAGE_NAME:latest"
+        fi

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -34,7 +34,7 @@ jobs:
   trigger-context:
     runs-on: ubuntu-latest
     outputs:
-      in_scope: ${{ steps.am-i-in-scope.outputs.in_scope }}
+      in_scope: ${{ steps.am_i_in_scope.outputs.in_scope }}
       allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
       is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
       pr_number: ${{ steps.pr_comment_context.outputs.pr_number }}
@@ -59,7 +59,8 @@ jobs:
     # Test whether we are either:
     #   a push 
     #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
-    - name: am-i-in-scope
+    - name: Check if trigger is in scope
+      if: am_i_in_scope
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -60,7 +60,7 @@ jobs:
     #   a push 
     #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
     - name: Check if trigger is in scope
-      if: am_i_in_scope
+      id: am_i_in_scope
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -34,7 +34,7 @@ jobs:
   trigger-context:
     runs-on: ubuntu-latest
     outputs:
-      in_scope: ${{ steps.am-i-in_scope.outputs.in_scope }}
+      in_scope: ${{ steps.am-i-in-scope.outputs.in_scope }}
       allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
       is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
       pr_number: ${{ steps.pr_comment_context.outputs.pr_number }}
@@ -59,13 +59,14 @@ jobs:
     # Test whether we are either:
     #   a push 
     #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
-    - name: am-i-in_scope
+    - name: am-i-in-scope
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \
           || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]); then
             echo trigger is in scope
             echo "::set-output name=in_scope::true"
+            echo "pretend to set-output name=in_scope::true"
         else
             echo trigger is out of scope
             # echo "::set-output name=in_scope::false"  # Don't set anything if false

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -41,7 +41,7 @@ jobs:
       from_pr_originator: ${{ steps.pr_comment_context.outputs.from_pr_originator }}
       event_ref: ${{ steps.pr_comment_context.outputs.event_ref }}
     steps:
-    - uses: ca-scribner/github-actions-recipes/get-pr-comment-context@24abb2d699ce6c7f8374404e4ccc7bd453bdf81a
+    - uses: ca-scribner/github-actions-recipes/get-pr-comment-context@86aad239d20c9f7555816dd634d60a896774c030
       id: pr_comment_context
       with: 
         allowed_author_associations: '[OWNER, COLLABORATOR]'
@@ -80,6 +80,7 @@ jobs:
     steps:
       - run: echo in_scope = ${{ needs.trigger-context.outputs.in_scope }}
       - run: echo is_pr_comment = ${{ needs.trigger-context.outputs.is_pr_comment }}
+
   build-push:
     needs:
       trigger-context
@@ -133,26 +134,6 @@ jobs:
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    # Container build and push to a Azure Container registry (ACR)
-    - name: Build image
-      run: |
-        make all
-        COMMIT=$(make get-commit)
-        echo
-        cd output/${{ matrix.notebook }}
-        docker build . --build-arg BASE_VERSION=$COMMIT -t localhost:5000/kubeflow-image:$SHORT_SHA
-        docker push localhost:5000/kubeflow-image:$SHORT_SHA
-        docker rmi localhost:5000/kubeflow-image:$SHORT_SHA
-        docker image prune
-        cd -
-
-    # Scan image for vulnerabilities
-    - uses: Azure/container-scan@v0
-      with:
-        image-name: localhost:5000/kubeflow-image:${{ env.SHORT_SHA }}
-        severity-threshold: CRITICAL
-        run-quality-checks: false
-
     # Get branch name for tagging. 
     # When triggered by a comment on a PR, ref points to master rather than true branch name
     - name: Get branch name on PR comment
@@ -173,6 +154,26 @@ jobs:
           BRANCH_NAME=${GITHUB_REF#refs/*/}
         fi
         echo "BRANCH_NAME=$(echo $BRANCH_NAME | cut -c 1-6)" >> $GITHUB_ENV
+
+    # Container build and push to a Azure Container registry (ACR)
+    - name: Build image
+      run: |
+        make all
+        COMMIT=$(make get-commit)
+        echo
+        cd output/${{ matrix.notebook }}
+        docker build . --build-arg BASE_VERSION=$COMMIT -t localhost:5000/kubeflow-image:$SHORT_SHA
+        docker push localhost:5000/kubeflow-image:$SHORT_SHA
+        docker rmi localhost:5000/kubeflow-image:$SHORT_SHA
+        docker image prune
+        cd -
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: localhost:5000/kubeflow-image:${{ env.SHORT_SHA }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false
 
     # Container push to a Azure Container registry (ACR)
     - name: Push image

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -34,6 +34,7 @@ jobs:
   trigger-context:
     runs-on: ubuntu-latest
     outputs:
+      in_scope: ${{ steps.am-i-in_scope.outputs.in_scope }}
       allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
       is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
       pr_number: ${{ steps.pr_comment_context.outputs.pr_number }}
@@ -58,16 +59,16 @@ jobs:
     # Test whether we are either:
     #   a push 
     #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
-    - name: am-i-in-scope
+    - name: am-i-in_scope
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \
           || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]); then
             echo trigger is in scope
-            echo "::set-output name=in-scope::true"
+            echo "::set-output name=in_scope::true"
         else
             echo trigger is out of scope
-            # echo "::set-output name=in-scope::false"  # Don't set anything if false
+            # echo "::set-output name=in_scope::false"  # Don't set anything if false
         fi
 
   test-print:
@@ -75,12 +76,12 @@ jobs:
       trigger-context
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.trigger-context.outputs.in-scope }}
-      - run: echo ${{ needs.trigger-context.outputs.is_pr_comment }}
+      - run: echo in_scope = ${{ needs.trigger-context.outputs.in_scope }}
+      - run: echo is_pr_comment = ${{ needs.trigger-context.outputs.is_pr_comment }}
   build-push:
     needs:
       trigger-context
-    if: needs.trigger-context.outputs.in-scope == 'true'  # Could also just be if in-scope, as it'll be empty if false
+    if: needs.trigger-context.outputs.in_scope == 'true'  # Could also just be if in_scope, as it'll be empty if false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -49,14 +49,17 @@ jobs:
       id: am_i_in_scope
       shell: bash
       run: |
+        # In scope if push or if PR-comment saying "/deploy" from a contributor/owner
         if   [ ${{ github.event_name }} == "push" ] \
-          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]); then
+          || (     [ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] \
+                && [ ${{ steps.pr_comment_context.outputs.allowed_author }} == "true" ] \
+                && [ "${{ github.event.comment.body }}" == "/deploy" ]); then
             echo trigger is in scope
             echo "::set-output name=in_scope::true"
             echo "pretend to set-output name=in_scope::true"
         else
             echo trigger is out of scope
-            # echo "::set-output name=in_scope::false"  # Don't set anything if false
+            # Return null if false
         fi
 
   build-push:

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -14,10 +14,10 @@
 # DEBUG: This is a temporary CI for testing.  This will be merged into push.yaml when complete, but must be tested on master branch (comment triggers only work on master)
 name: push on comment
 on:
-  push:
-    branches:
+  # push:
+    # branches:
       # - master  # DEBUG Removed during debugging
-      - add-deploy-triggers # DEBUG Added during debugging
+      # - add-deploy-triggers # DEBUG Added during debugging
   issue_comment:
     types:
       - created
@@ -45,20 +45,6 @@ jobs:
       id: pr_comment_context
       with: 
         allowed_author_associations: '[OWNER, COLLABORATOR]'
-      # TRY TO EXIT WITH SUCCESS ASAP, THEN THE OTHER IF FAILURES CAN CONTINUE?  Not sure
-    # - name: am-i-push
-    #   if: github.event_name == 'push'
-    #   run: exit 0
-    # - name: am-i-pr-comment
-    #   if: failure() && steps.pr_comment_context.outputs.is_pr_comment
-    #   run: exit 0
-    # - name: else fail
-    #   run: exit 1
-    # - name: collect-output
-    #   if: !contains
-    # Test whether we are either:
-    #   a push 
-    #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
     - name: Check if trigger is in scope
       id: am_i_in_scope
       shell: bash
@@ -72,14 +58,6 @@ jobs:
             echo trigger is out of scope
             # echo "::set-output name=in_scope::false"  # Don't set anything if false
         fi
-
-  test-print:
-    needs:
-      trigger-context
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo in_scope = ${{ needs.trigger-context.outputs.in_scope }}
-      - run: echo is_pr_comment = ${{ needs.trigger-context.outputs.is_pr_comment }}
 
   build-push:
     needs:
@@ -116,7 +94,9 @@ jobs:
 
       # DEBUG Does GITHUB_SHA work for issue_comment?
     - name: Add SHORT_SHA env property with commit short sha
-      run:  echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      run:  |
+        echo "SHORT_SHA=${GITHUB_SHA}"
+        echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
 
     - name: Test output folder
       run: |
@@ -135,23 +115,19 @@ jobs:
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
     # Get branch name for tagging. 
-    # When triggered by a comment on a PR, ref points to master rather than true branch name
-    - name: Get branch name on PR comment
-      id: get-branch-name
-      if: needs.trigger-context.outputs.is_pr_comment
-      with: 
-        owner: ${{ github.event.repository.owner.login }}
-        repository: ${{ github.event.repository.name }}
-        pr_number: ${{ needs.trigger-context.outputs.pr_number }}
-      uses: ca-scribner/github-actions-recipes/get-branch-name-of-pr@fb78f53adf9877c3916e63b44cfb4132b9cdf4b7
-
+    # Depending on whether this is a push or a pr-comment, branch name is discoverable differently.
     - name: Report branch name on PR comment
       id: report-branch-name
       shell: bash
       run: |
         if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
-          BRANCH_NAME=${{ steps.get-branch-name.outputs.branch }}
+          # Use Github API to get branch name from PR details
+          OWNER=${{ github.event.repository.owner.login }}
+          REPOSITORY=${{ github.event.repository.name }}
+          PR_NUMBER=${{ needs.trigger-context.outputs.pr_number }}
+          BRANCH_NAME=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$OWNER/$REPOSITORY/pulls/$PR_NUMBER | jq '.head.ref')
         else
+          # Extract branch name from Github context's ref variable
           BRANCH_NAME=${GITHUB_REF#refs/*/}
         fi
         echo "BRANCH_NAME=$(echo $BRANCH_NAME | cut -c 1-6)" >> $GITHUB_ENV
@@ -189,15 +165,13 @@ jobs:
 
         echo
         docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$SHORT_SHA
-        # docker push $REGISTRY/$IMAGE_NAME:$SHORT_SHA
+        docker push $REGISTRY/$IMAGE_NAME:$SHORT_SHA
         docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$BRANCH_NAME
-        # DEBUG: Removed during debugging
-        # docker push $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}  # I think this breaks for PR comments
+        docker push $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}  # I think this breaks for PR comments
 
         if ["$BRANCH_NAME" == "master"]; then
-        # DEBUG: Removed during debugging
           docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:latest
-        # docker push $REGISTRY/$IMAGE_NAME:latest
+        docker push $REGISTRY/$IMAGE_NAME:latest
         fi
 
         # Report

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -34,7 +34,6 @@ jobs:
   trigger-context:
     runs-on: ubuntu-latest
     outputs:
-      in-scope: ${{ steps.am-i-in-scope.conclusion }}
       allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
       is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
       pr_number: ${{ steps.pr_comment_context.outputs.pr_number }}
@@ -65,21 +64,23 @@ jobs:
         if   [ ${{ github.event_name }} == "push" ] \
           || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]); then
             echo trigger is in scope
-            exit 0
+            echo "::set-output name=in-scope::true"
         else
-          echo trigger is out of scope
-          exit 1
+            echo trigger is out of scope
+            # echo "::set-output name=in-scope::false"  # Don't set anything if false
         fi
+
   test-print:
     needs:
       trigger-context
     runs-on: ubuntu-latest
     steps:
       - run: echo ${{ needs.trigger-context.outputs.in-scope }}
+      - run: echo ${{ needs.trigger-context.outputs.is_pr_comment }}
   build-push:
     needs:
       trigger-context
-    if: needs.trigger-context.outputs.in-scope == 'success'
+    if: needs.trigger-context.outputs.in-scope == 'true'  # Could also just be if in-scope, as it'll be empty if false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -63,7 +63,7 @@ jobs:
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \
-          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]; then
+          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]); then
             echo trigger is in scope
             exit 0
         else

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -41,7 +41,7 @@ jobs:
       from_pr_originator: ${{ steps.pr_comment_context.outputs.from_pr_originator }}
       event_ref: ${{ steps.pr_comment_context.outputs.event_ref }}
     steps:
-    - uses: ca-scribner/github-actions-recipes/get-pr-comment-context@c84d32bd0e09152cf06136f4f56967d6631e66e4
+    - uses: ca-scribner/github-actions-recipes/get-pr-comment-context@24abb2d699ce6c7f8374404e4ccc7bd453bdf81a
       id: pr_comment_context
       with: 
         allowed_author_associations: '[OWNER, COLLABORATOR]'
@@ -91,7 +91,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
-    - uses: ca-scribner/github-actions-recipes/get-event-ref-on-pr@c84d32bd0e09152cf06136f4f56967d6631e66e4
+    - uses: ca-scribner/github-actions-recipes/get-event-ref-on-pr@24abb2d699ce6c7f8374404e4ccc7bd453bdf81a
       id: event_ref
     - uses: actions/checkout@master
     

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -148,7 +148,7 @@ jobs:
     - name: Report branch name on PR comment
       id: report-branch-name
       shell: bash
-      run: 
+      run: |
         if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
           BRANCH_NAME=${{ steps.get-branch-name.outputs.branch }}
         else

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -1,0 +1,167 @@
+# This workflow will build a docker container, publish it to Azure Container Registry, and deploy it to Azure Kubernetes Service using a helm chart.
+#
+# https://github.com/Azure/actions-workflow-samples/tree/master/Kubernetes
+#
+# To configure this workflow:
+#
+# 1. Set up the following secrets in your workspace:
+#     a. REGISTRY_USERNAME with ACR username
+#     b. REGISTRY_PASSWORD with ACR Password
+#     c. AZURE_CREDENTIALS with the output of `az ad sp create-for-rbac --sdk-auth`
+#
+# 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below).
+
+# DEBUG: This is a temporary CI for testing.  This will be merged into push.yaml when complete, but must be tested on master branch (comment triggers only work on master)
+name: push on comment
+on:
+  push:
+    branches:
+      # - master  # DEBUG Removed during debugging
+      - add-deploy-triggers # DEBUG Added during debugging
+  issue_comment:
+    types:
+      - created
+
+# Environment variables available to all jobs and steps in this workflow
+env:
+  REGISTRY: k8scc01covidacr.azurecr.io
+  REGISTRY_NAME: k8scc01covidacr
+  CLUSTER_NAME: k8s-cancentral-01-covid-aks
+  CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
+jobs:
+  # Do initial tests to see if we should run (push or an issue_comment on a PR) or if we should ignore (an issue_comment NOT on a PR)
+  # Inspired by https://stackoverflow.com/a/61832535/5394584
+  trigger-context:
+    runs-on: ubuntu-latest
+    shell: bash
+    output:
+      in-scope: ${{ steps.am-i-in-scope.conclusion }}
+      allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
+      is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
+      pr_number: ${{ steps.pr_comment_context.outputs.pr_number }}
+      from_pr_originator: ${{ steps.pr_comment_context.outputs.from_pr_originator }}
+      event_ref: ${{ steps.pr_comment_context.outputs.event_ref }}
+    steps:
+    - uses: ca-scribner/github-actions-recipes/get-pr-comment-context@c84d32bd0e09152cf06136f4f56967d6631e66e4
+      id: pr_comment_context
+      with: 
+        allowed_author_associations: '[OWNER, COLLABORATOR]'
+      # TRY TO EXIT WITH SUCCESS ASAP, THEN THE OTHER IF FAILURES CAN CONTINUE?  Not sure
+    # - name: am-i-push
+    #   if: github.event_name == 'push'
+    #   run: exit 0
+    # - name: am-i-pr-comment
+    #   if: failure() && steps.pr_comment_context.outputs.is_pr_comment
+    #   run: exit 0
+    # - name: else fail
+    #   run: exit 1
+    # - name: collect-output
+    #   if: !contains
+    # Test whether we are either:
+    #   a push 
+    #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
+    - name: am-i-in-scope
+      run: |
+        if   [ ${{ github.event_name == "push" }} ] \
+          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment == "true" }} ] && [ ${{steps.pr_comment_context.outputs.allowed_author == "true" }}]; then
+            echo trigger is in scope
+            exit 0
+        else
+          echo trigger is out of scope
+          exit 1
+        fi
+  build-push:
+    needs:
+      trigger-context
+    if: needs.trigger-context.outputs.in-scope == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        notebook:
+          - JupyterLab-CPU
+          # DEBUG images removed during debugging
+          # - JupyterLab-PyTorch
+          # - JupyterLab-Tensorflow
+          # - RStudio
+          # - JupyterLab-CPU-OL-compliant     
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+    - uses: ca-scribner/github-actions-recipes/get-event-ref-on-pr@c84d32bd0e09152cf06136f4f56967d6631e66e4
+      id: event_ref
+    - uses: actions/checkout@master
+    
+    # Extra checkout step to ensure we checkout PR's code when this triggers on PR comment
+    # Without this, we will always check out master
+    - name: Checkout PR code
+      if: github.event_name == 'issue_comment'
+      run: |
+         git fetch origin ${{ steps.event_ref.outputs.event_ref }}
+         git checkout FETCH_HEAD
+
+      # DEBUG Does GITHUB_SHA work for issue_comment?
+    - name: Add SHORT_SHA env property with commit short sha
+      run:  echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+    - name: Test output folder
+      run: |
+        sudo apt-get install --yes make
+        make all
+        if ! git diff --quiet output/; then
+            echo 'output folder and docker-bits/resources out of sync!'
+            exit 1
+        fi
+
+    # Connect to Azure Container registry (ACR)
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ env.REGISTRY_NAME }}.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    # Container build and push to a Azure Container registry (ACR)
+    - name: Build image
+      run: |
+        make all
+        COMMIT=$(make get-commit)
+        echo
+        cd output/${{ matrix.notebook }}
+        docker build . --build-arg BASE_VERSION=$COMMIT -t localhost:5000/kubeflow-image:$SHORT_SHA
+        docker push localhost:5000/kubeflow-image:$SHORT_SHA
+        docker rmi localhost:5000/kubeflow-image:$SHORT_SHA
+        docker image prune
+        cd -
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: localhost:5000/kubeflow-image:${{ env.SHORT_SHA }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false
+
+    # Container push to a Azure Container registry (ACR)
+    - name: Push image
+      run: |
+        echo Repull the image
+        docker pull localhost:5000/kubeflow-image:$SHORT_SHA
+        docker tag localhost:5000/kubeflow-image:$SHORT_SHA kubeflow-image
+        echo
+        IMAGE_NAME="$(echo ${{ matrix.notebook }} | tr '[:upper:]' '[:lower:]')"
+        REGISTRY=${{ env.REGISTRY }}
+        echo
+        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:$SHORT_SHA
+        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}
+        docker tag kubeflow-image $REGISTRY/$IMAGE_NAME:latest
+        echo
+        # DEBUG: Removed during debugging
+        # docker push $REGISTRY/$IMAGE_NAME:$SHORT_SHA
+        # docker push $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}  # I think this breaks for PR comments
+        # docker push $REGISTRY/$IMAGE_NAME:latest
+        echo
+        echo "Pushed $REGISTRY/$IMAGE_NAME:$SHORT_SHA"
+        echo "       $REGISTRY/$IMAGE_NAME:${GITHUB_REF#refs/*/}"
+        echo "       $REGISTRY/$IMAGE_NAME:latest"

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -83,6 +83,20 @@ jobs:
         ports:
           - 5000:5000
     steps:
+    - name: Notify start via comment
+      if: needs.trigger-context.outputs.is_pr_comment
+      id: notify-start
+      uses: actions/github-script@v1
+      with: 
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Build activated.  Track in [Github Actions](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/).  I will report back when things are pushed!`
+          })
+
     - uses: ca-scribner/github-actions-recipes/get-event-ref-on-pr@24abb2d699ce6c7f8374404e4ccc7bd453bdf81a
       id: event_ref
     - uses: actions/checkout@master
@@ -133,7 +147,7 @@ jobs:
           # Extract branch name from Github context's ref variable
           BRANCH_NAME=${GITHUB_REF#refs/*/}
         fi
-        echo "BRANCH_NAME=$(echo $BRANCH_NAME | cut -c 1-6)" >> $GITHUB_ENV
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
     # Container build and push to a Azure Container registry (ACR)
     - name: Build image
@@ -157,6 +171,7 @@ jobs:
 
     # Container push to a Azure Container registry (ACR)
     - name: Push image
+      id: push-image
       run: |
         echo Repull the image
         docker pull localhost:5000/kubeflow-image:$SHORT_SHA
@@ -184,3 +199,25 @@ jobs:
         if ["$BRANCH_NAME" == "master"]; then
           echo "       $REGISTRY/$IMAGE_NAME:latest"
         fi
+
+    # This notification uses a semi-hardcoded image name.  There's probably a better way
+    - name: Notify end via comment
+      if: needs.trigger-context.outputs.is_pr_comment
+      id: notify-end
+      uses: actions/github-script@v1
+      with: 
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          var IMAGE_NAME = process.env.IMAGE_NAME
+          var REGISTRY = process.env.REGISTRY
+          var SHORT_SHA = process.env.SHORT_SHA
+
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Build complete for image: ${IMAGE_NAME}.  Test your image in [kubeflow](https://kubeflow.covid.cloud.statcan.ca/_/jupyter) by creating a Notebook Server using custom image ${REGISTRY}/${SHORT_SHA}`
+          })
+      env:
+        IMAGE_NAME: ${{ matrix.notebook }}
+        REGISTRY: ${{ env.REGISTRY }}

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -33,8 +33,7 @@ jobs:
   # Inspired by https://stackoverflow.com/a/61832535/5394584
   trigger-context:
     runs-on: ubuntu-latest
-    shell: bash
-    output:
+    outputs:
       in-scope: ${{ steps.am-i-in-scope.conclusion }}
       allowed_author: ${{ steps.pr_comment_context.outputs.allowed_author }}
       is_pr_comment: ${{ steps.pr_comment_context.outputs.is_pr_comment }}
@@ -61,6 +60,7 @@ jobs:
     #   a push 
     #   a comment on a PR (eg: not just a comment on a random issue) from a contributor/owner
     - name: am-i-in-scope
+      shell: bash
       run: |
         if   [ ${{ github.event_name == "push" }} ] \
           || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment == "true" }} ] && [ ${{steps.pr_comment_context.outputs.allowed_author == "true" }}]; then

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -147,6 +147,7 @@ jobs:
 
     - name: Report branch name on PR comment
       id: report-branch-name
+      shell: bash
       run: 
         if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
           BRANCH_NAME=${{ steps.get-branch-name.outputs.branch }}

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -70,6 +70,12 @@ jobs:
           echo trigger is out of scope
           exit 1
         fi
+  test-print:
+    needs:
+      trigger-context
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ needs.trigger-context.outputs.in-scope }}
   build-push:
     needs:
       trigger-context

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: am-i-in-scope
       shell: bash
       run: |
-        if   [ ${{ github.event_name == "push" }} ] \
+        if   [ ${{ github.event_name }} == "push" ] \
           || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment == "true" }} ] && [ ${{steps.pr_comment_context.outputs.allowed_author == "true" }}]; then
             echo trigger is in scope
             exit 0

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -63,7 +63,7 @@ jobs:
       shell: bash
       run: |
         if   [ ${{ github.event_name }} == "push" ] \
-          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment == "true" }} ] && [ ${{steps.pr_comment_context.outputs.allowed_author == "true" }}]; then
+          || ([ ${{ steps.pr_comment_context.outputs.is_pr_comment }} == "true" ] && [ ${{steps.pr_comment_context.outputs.allowed_author }} == "true" ]; then
             echo trigger is in scope
             exit 0
         else

--- a/.github/workflows/push_on_comment.yaml
+++ b/.github/workflows/push_on_comment.yaml
@@ -148,7 +148,7 @@ jobs:
     - name: Report branch name on PR comment
       id: report-branch-name
       run: 
-        if [ "${{ needs.trigger-context.outputs.is_pr_comment }} == "true" ]; then
+        if [ "${{ needs.trigger-context.outputs.is_pr_comment }}" == "true" ]; then
           BRANCH_NAME=${{ steps.get-branch-name.outputs.branch }}
         else
           BRANCH_NAME=${GITHUB_REF#refs/*/}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ docker run -p 8888:8888 tagName:version
 ```
 Now open in http://localhost:8888/.
 
+### Development Testing Instructions for CI
+
+If making changes to CI that cannot be done on a branch (eg: changes to issue_comment triggers), you can:
+* fork the 'kubeflow-containers' repo
+* Modify the CI with 
+  * REGISTRY: (your own dockerhub repo, eg: "j-smith" (no need for the full url))
+  * Change 
+  	```
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ env.REGISTRY_NAME }}.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+  	```
+  	to 
+  	```
+    - uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    ```
+  * In your forked repo, define secrets for REGISTRY_USERNAME and REGISTRY_PASSWORD with your dockerhub credentials (you should use an API token, not your actual dockerhub password)
+
 ## Troubleshooting
 If running using a VM and RStudio image was built successfully but is not opening correctly on localhost (error 5000 page), change your CPU allocation in your Linux VM settings to >= 3. You can also use your VM's system monitor to examine if all CPUs are 100% being used as your container is running. If so, increase CPU allocation. 
 This was tested on Linux Ubuntu 20.04 virtual machine.


### PR DESCRIPTION
Adds a "/deploy" keyword to our PRs.  If a repo owner or collaborator comments on a PR with "/deploy", CI will trigger a build+push step for this branch.  Images will be pushed to the main ACR under tags of `:SHA` and `:BRANCH`, and can then be accessed as custom images.  

To prove this works completely, it needs to be merged into master (github actions triggering on comments must be in master branch).  I've debugged in another repo but just in case, to start this does not replace `push.yaml` but instead is a secondary workflow that applies only to JupyterLab-CPU.  If it proves to work well, we can replace `push.yaml` and use this for all push events.  

Will squash on merge to remove the junk commits.