### PR TITLE
feat: add newly introduced prometheus no-auth flag

### DIFF
--- a/output/JupyterLab-CPU-OL-compliant/helpers.sh
+++ b/output/JupyterLab-CPU-OL-compliant/helpers.sh
@@ -31,7 +31,7 @@ Conda
 =====
 
 It's recommended that you use conda to create virtual environments and
-to insall R, Python, or Julia packages.
+to install R, Python, or Julia packages.
 
 
 Have fun!!!

--- a/output/JupyterLab-CPU-OL-compliant/start-custom.sh
+++ b/output/JupyterLab-CPU-OL-compliant/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/JupyterLab-CPU/start-custom.sh
+++ b/output/JupyterLab-CPU/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/JupyterLab-PyTorch-OL-compliant/helpers.sh
+++ b/output/JupyterLab-PyTorch-OL-compliant/helpers.sh
@@ -31,7 +31,7 @@ Conda
 =====
 
 It's recommended that you use conda to create virtual environments and
-to insall R, Python, or Julia packages.
+to install R, Python, or Julia packages.
 
 
 Have fun!!!

--- a/output/JupyterLab-PyTorch-OL-compliant/start-custom.sh
+++ b/output/JupyterLab-PyTorch-OL-compliant/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/JupyterLab-PyTorch/start-custom.sh
+++ b/output/JupyterLab-PyTorch/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/JupyterLab-Tensorflow-OL-compliant/helpers.sh
+++ b/output/JupyterLab-Tensorflow-OL-compliant/helpers.sh
@@ -31,7 +31,7 @@ Conda
 =====
 
 It's recommended that you use conda to create virtual environments and
-to insall R, Python, or Julia packages.
+to install R, Python, or Julia packages.
 
 
 Have fun!!!

--- a/output/JupyterLab-Tensorflow-OL-compliant/start-custom.sh
+++ b/output/JupyterLab-Tensorflow-OL-compliant/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/JupyterLab-Tensorflow/start-custom.sh
+++ b/output/JupyterLab-Tensorflow/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/output/RStudio/start-custom.sh
+++ b/output/RStudio/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}

--- a/resources/start-custom.sh
+++ b/resources/start-custom.sh
@@ -28,10 +28,10 @@ if [ -n "${KF_LANG}" ]; then
         export LANG="en_US.utf8"
     else
         export LANG="fr_CA.utf8"
-        
+
         #  User's browser lang is set to french, open jupyterlab in french (fr_FR)
-        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then               
-          export LANG="fr_FR"     
+        if [ "${DEFAULT_JUPYTER_URL}" != "/rstudio" ]; then
+          export LANG="fr_FR"
           lang_file="/home/${NB_USER}/.jupyter/lab/user-settings/@jupyterlab/translation-extension/plugin.jupyterlab-settings"
           mkdir -p "$(dirname "${lang_file}")" && touch $lang_file
           ( echo    '{'
@@ -43,7 +43,7 @@ if [ -n "${KF_LANG}" ]; then
             echo     '   // Définit la langue d'\''affichage de l'\''interface. Exemples: '\''es_CO'\'', '\''fr'\''.'
             echo     '   "locale": "'${LANG}'"'
             echo     '}'
-          ) >> $lang_file            
+          ) >> $lang_file
         fi
     fi
 fi
@@ -68,5 +68,6 @@ jupyter notebook --notebook-dir=/home/${NB_USER} \
                  --NotebookApp.token='' \
                  --NotebookApp.password='' \
                  --NotebookApp.allow_origin='*' \
+                 --NotebookApp.authenticate_prometheus=False \
                  --NotebookApp.base_url=${NB_PREFIX} \
                  --NotebookApp.default_url=${DEFAULT_JUPYTER_URL:-/tree}


### PR DESCRIPTION
Adds a new flag

https://github.com/jupyter/notebook/commit/c0ab18a53472372e31dee293fefd66f218107c98

Which would otherwise prevent us from scraping `/metrics`.

(We currently can scrape metrics, but this will break once we upgrade to the newer docker-stacks base images.)