### PR TITLE
fix: Extend timeout for Trivy in build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,6 +65,8 @@ jobs:
 
     # Scan image for vulnerabilities
     - uses: Azure/container-scan@v0
+      env:
+        TRIVY_TIMEOUT: 10m0s  # Trivy default is 2min.  Some images take a bit longer
       with:
         image-name: localhost:5000/kubeflow-image:${{ env.SHORT_SHA }}
         severity-threshold: CRITICAL

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -75,6 +75,8 @@ jobs:
 
     # Scan image for vulnerabilities
     - uses: Azure/container-scan@v0
+      env:
+        TRIVY_TIMEOUT: 10m0s  # Trivy default is 2min.  Some images take a bit longer
       with:
         image-name: localhost:5000/kubeflow-image:${{ env.SHORT_SHA }}
         severity-threshold: CRITICAL


### PR DESCRIPTION
pytorch scan timed out (took longer than 2 min).  Extending timeout to fix