### PR TITLE
chore(ci): add nightly testing build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,9 @@
 # 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below).
 name: build
 on:
+  schedule:
+    # Execute at 2am EST every day
+    - cron:  '0 21 * * *'
   push:
     branches:
       - '*'


### PR DESCRIPTION
Build (without pushing) every night at 2:am, to make sure everything is happy and healthy