### PR TITLE
chore: update code server and python version

### DIFF
--- a/docker-bits/6_jupyterlab-ol-compliant.Dockerfile
+++ b/docker-bits/6_jupyterlab-ol-compliant.Dockerfile
@@ -7,8 +7,8 @@
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -25,9 +25,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/docker-bits/6_jupyterlab-ol-compliant.Dockerfile
+++ b/docker-bits/6_jupyterlab-ol-compliant.Dockerfile
@@ -7,8 +7,8 @@
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
-ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
+ARG VSCODE_VERSION=3.9.3
+ARG VSCODE_SHA=5e01af26e20de9dd83fa64f2056438bf252f9a0dbe43f4f597508cfaa0f3ccbb
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -2,7 +2,7 @@
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_VERSION=3.9.3
 ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -2,8 +2,8 @@
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -20,9 +20,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-cpu-ol-compliant/Dockerfile
+++ b/output/jupyterlab-cpu-ol-compliant/Dockerfile
@@ -124,8 +124,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
-ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
+ARG VSCODE_VERSION=3.9.3
+ARG VSCODE_SHA=5e01af26e20de9dd83fa64f2056438bf252f9a0dbe43f4f597508cfaa0f3ccbb
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root

--- a/output/jupyterlab-cpu-ol-compliant/Dockerfile
+++ b/output/jupyterlab-cpu-ol-compliant/Dockerfile
@@ -124,8 +124,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -142,9 +142,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -119,7 +119,7 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_VERSION=3.9.3
 ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -119,8 +119,8 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -137,9 +137,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-pytorch-ol-compliant/Dockerfile
+++ b/output/jupyterlab-pytorch-ol-compliant/Dockerfile
@@ -221,8 +221,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -239,9 +239,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-pytorch-ol-compliant/Dockerfile
+++ b/output/jupyterlab-pytorch-ol-compliant/Dockerfile
@@ -221,8 +221,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
-ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
+ARG VSCODE_VERSION=3.9.3
+ARG VSCODE_SHA=5e01af26e20de9dd83fa64f2056438bf252f9a0dbe43f4f597508cfaa0f3ccbb
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -216,8 +216,8 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -234,9 +234,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -216,7 +216,7 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_VERSION=3.9.3
 ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 

--- a/output/jupyterlab-tensorflow-ol-compliant/Dockerfile
+++ b/output/jupyterlab-tensorflow-ol-compliant/Dockerfile
@@ -216,8 +216,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
-ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
+ARG VSCODE_VERSION=3.9.3
+ARG VSCODE_SHA=5e01af26e20de9dd83fa64f2056438bf252f9a0dbe43f4f597508cfaa0f3ccbb
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root

--- a/output/jupyterlab-tensorflow-ol-compliant/Dockerfile
+++ b/output/jupyterlab-tensorflow-ol-compliant/Dockerfile
@@ -216,8 +216,8 @@ RUN apt-get update && \
 # Use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -234,9 +234,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -211,8 +211,8 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.8.0
-ARG VSCODE_SHA=ee10f45b570050939cafd162fbdc52feaa03f2da89d7cdb8c42bea0a0358a32a
+ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
@@ -229,9 +229,9 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
 ENV XDG_DATA_HOME=/etc/share
 ENV SERVICE_URL=https://extensions.coder.com/api
 COPY vscode-overrides.json $XDG_DATA_HOME/code-server/User/settings.json
-ARG SHA256py=a4191fefc0e027fbafcd87134ac89a8b1afef4fd8b9dc35f14d6ee7bdf186348
+ARG SHA256py=11f89b561a0821b25d7cb612cad40c064e95676986497bcf658b0dca7f78e7e8
 
-RUN VS_PYTHON_VERSION="2020.5.86806" && \
+RUN VS_PYTHON_VERSION="2021.2.633441544" && \
     wget --quiet --no-check-certificate https://github.com/microsoft/vscode-python/releases/download/$VS_PYTHON_VERSION/ms-python-release.vsix && \
     echo "${SHA256py} ms-python-release.vsix" | sha256sum -c - && \
     code-server --install-extension ms-python-release.vsix && \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -211,7 +211,7 @@ RUN apt-get update && \
 # TODO: Change jupyterlab-git pre-release install to official v0.30.0 release once available
 
 # Install vscode
-ARG VSCODE_VERSION=3.9.1
+ARG VSCODE_VERSION=3.9.3
 ARG VSCODE_SHA=9e54ccff4c3f2b3f1837abf43a472e09c5bea697c00720b3f8967d4f43585e99
 ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 


### PR DESCRIPTION
# Description

Hopefully fixes the critical severity found in the current code-server version

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
