### PR TITLE
fix: use xdg-settings to make firefox default

### DIFF
--- a/output/remote-desktop/start-remote-desktop.sh
+++ b/output/remote-desktop/start-remote-desktop.sh
@@ -77,6 +77,7 @@ unset DBUS_SESSION_BUS_ADDRESS
 startxfce4 &
 
 # Makes an unbelievable difference in speed
+(sleep 10 && xdg-settings set default-web-browser firefox.desktop) &
 (sleep 10 && xfconf-query -c xfwm4 -p /general/use_compositing -s false && dconf write /org/gnome/terminal/legacy/profiles/custom-command "'/bin/bash'") &
 EOF
     chmod +x $HOME/.vnc/xstartup

--- a/resources/remote-desktop/start-remote-desktop.sh
+++ b/resources/remote-desktop/start-remote-desktop.sh
@@ -77,6 +77,7 @@ unset DBUS_SESSION_BUS_ADDRESS
 startxfce4 &
 
 # Makes an unbelievable difference in speed
+(sleep 10 && xdg-settings set default-web-browser firefox.desktop) &
 (sleep 10 && xfconf-query -c xfwm4 -p /general/use_compositing -s false && dconf write /org/gnome/terminal/legacy/profiles/custom-command "'/bin/bash'") &
 EOF
     chmod +x $HOME/.vnc/xstartup


### PR DESCRIPTION
Good catch. I never use the doc anymore so didn't notice :( 

Closes #265 
