### PR TITLE
feat: Block Download from palette vscode

### DIFF
--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -11,9 +11,9 @@
 # TODO: use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.10.0
-ARG VSCODE_SHA=ce4e252a47682319e27d836bb443d6246938db4be2c3bfbc80793a5939e35604
-ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+ARG VSCODE_VERSION=3.10.2-nodownload
+ARG VSCODE_SHA=8d5a7cef22ef0bafef635518721efd348cfecd40e65c076908e17b33fe1cc62c
+ARG VSCODE_URL=https://github.com/StatCan/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -141,9 +141,9 @@ RUN apt-get update && \
 # TODO: use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.10.0
-ARG VSCODE_SHA=ce4e252a47682319e27d836bb443d6246938db4be2c3bfbc80793a5939e35604
-ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+ARG VSCODE_VERSION=3.10.2-nodownload
+ARG VSCODE_SHA=8d5a7cef22ef0bafef635518721efd348cfecd40e65c076908e17b33fe1cc62c
+ARG VSCODE_URL=https://github.com/StatCan/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -238,9 +238,9 @@ RUN apt-get update && \
 # TODO: use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.10.0
-ARG VSCODE_SHA=ce4e252a47682319e27d836bb443d6246938db4be2c3bfbc80793a5939e35604
-ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+ARG VSCODE_VERSION=3.10.2-nodownload
+ARG VSCODE_SHA=8d5a7cef22ef0bafef635518721efd348cfecd40e65c076908e17b33fe1cc62c
+ARG VSCODE_URL=https://github.com/StatCan/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -233,9 +233,9 @@ RUN apt-get update && \
 # TODO: use official package jupyterlab-language-pack-fr-FR when released by Jupyterlab instead of the StatCan/jupyterlab-language-pack-fr_FR repo.
 
 # Install vscode
-ARG VSCODE_VERSION=3.10.0
-ARG VSCODE_SHA=ce4e252a47682319e27d836bb443d6246938db4be2c3bfbc80793a5939e35604
-ARG VSCODE_URL=https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+ARG VSCODE_VERSION=3.10.2-nodownload
+ARG VSCODE_SHA=8d5a7cef22ef0bafef635518721efd348cfecd40e65c076908e17b33fe1cc62c
+ARG VSCODE_URL=https://github.com/StatCan/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
 USER root
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \


### PR DESCRIPTION
Using a forked repo release where it is removed.
2/2 Closes https://github.com/StatCan/daaas/issues/568

# Description

**What your PR adds/fixes/removes**
Changes the code-server we are using for 3.10.2 and a release where the Download Command was removed from the palette.

# Tests / Quality Checks

## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [x] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [x] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [x] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
