### PR TITLE
chore(update OpenM++)

### DIFF
--- a/docker-bits/6_remote-desktop.Dockerfile
+++ b/docker-bits/6_remote-desktop.Dockerfile
@@ -273,8 +273,9 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # OpenM++ Install
-ENV OMPP_VERSION="1.9.4"
-ENV OMPP_PKG_DATE="20211130"
+ENV OMPP_VERSION="1.9.8"
+ENV OMPP_PKG_DATE="20220323"
+ARG SHA256ompp=9882798fe2738729cac14d8a62cac8c285fca44e12b8b575ec0d0e6b03ab7a02
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100
@@ -285,6 +286,7 @@ ENV OM_ROOT=/opt/openmpp
 # OpenM++ expects sqlite to be installed (not just libsqlite)
 RUN apt-get install --yes sqlite3
 RUN wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
     && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} $OM_ROOT \
     && chown -R $NB_UID:$NB_GID $OM_ROOT

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -400,8 +400,9 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # OpenM++ Install
-ENV OMPP_VERSION="1.9.4"
-ENV OMPP_PKG_DATE="20211130"
+ENV OMPP_VERSION="1.9.8"
+ENV OMPP_PKG_DATE="20220323"
+ARG SHA256ompp=9882798fe2738729cac14d8a62cac8c285fca44e12b8b575ec0d0e6b03ab7a02
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100
@@ -412,6 +413,7 @@ ENV OM_ROOT=/opt/openmpp
 # OpenM++ expects sqlite to be installed (not just libsqlite)
 RUN apt-get install --yes sqlite3
 RUN wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_ubuntu_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
     && mv /tmp/openmpp_ubuntu_${OMPP_PKG_DATE} $OM_ROOT \
     && chown -R $NB_UID:$NB_GID $OM_ROOT


### PR DESCRIPTION
# Description

Update OpenM++

# Tests / Quality Checks

## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test (e.g. `k8scc01covidacr.azurecr.io/machine-learning-notebook-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?

Closes https://github.com/StatCan/aaw-kubeflow-containers/issues/335