### PR TITLE
Update start-oms.sh

### DIFF
--- a/output/docker-stacks-datascience-notebook/start-oms.sh
+++ b/output/docker-stacks-datascience-notebook/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/jupyterlab-cpu/start-oms.sh
+++ b/output/jupyterlab-cpu/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/jupyterlab-pytorch/start-oms.sh
+++ b/output/jupyterlab-pytorch/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/jupyterlab-tensorflow/start-oms.sh
+++ b/output/jupyterlab-tensorflow/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/remote-desktop/start-oms.sh
+++ b/output/remote-desktop/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/rstudio/start-oms.sh
+++ b/output/rstudio/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/output/sas/start-oms.sh
+++ b/output/sas/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then

--- a/resources/common/start-oms.sh
+++ b/resources/common/start-oms.sh
@@ -80,7 +80,7 @@ if [ ! -d /openmpp ]
   git clone https://github.com/StatCan/openmpp.git
 fi
 cd openmpp
-branch="main"
+branch="31-model-data-isolation"
 state=$(git symbolic-ref --short HEAD 2>&1)
 if [ $state != $branch ]
  then


### PR DESCRIPTION
# Description
Do not pull.  PR created to create a custom image to test opem-31 test model isolation!


## Code review

- [x ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [x ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
