### PR TITLE
main: add new URL for SAS 9.4 M8

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -63,8 +63,6 @@ jobs:
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.31.3"
       HADOLINT_VERSION: "2.12.0"
-      ACCOUNT_NAME: ${{ secrets.BRYAN_SA_NAME }}
-      SRC_ACCOUNT_KEY: ${{ secrets.BRYAN_SA_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -142,7 +140,7 @@ jobs:
     # make build emits full_image_name, image_tag, and image_repo outputs
     - name: Build image
       id: build-image
-      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
+      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} ACCOUNT_NAME=${{ secrets.BRYAN_SA_NAME SRC_ACCOUNT_KEY=${{ secrets.BRYAN_SA_KEY }}
 
     - name: Echo disk usage after build completion
       run: ./.github/scripts/echo_usage.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -142,7 +142,10 @@ jobs:
     # make build emits full_image_name, image_tag, and image_repo outputs
     - name: Build image
       id: build-image
-      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }}
+      with:
+        ACCOUNT_NAME: ${{ secrets.BRYAN_SA_NAME }}
+        SRC_ACCOUNT_KEY: ${{ secrets.BRYAN_SA_KEY }}
+      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} 
 
     - name: Echo disk usage after build completion
       run: ./.github/scripts/echo_usage.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -140,7 +140,7 @@ jobs:
     # make build emits full_image_name, image_tag, and image_repo outputs
     - name: Build image
       id: build-image
-      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} ACCOUNT_NAME=${{ secrets.BRYAN_SA_NAME SRC_ACCOUNT_KEY=${{ secrets.BRYAN_SA_KEY }}
+      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} ACCOUNT_NAME=${{ secrets.BRYAN_SA_NAME }} SRC_ACCOUNT_KEY=${{ secrets.BRYAN_SA_KEY }}
 
     - name: Echo disk usage after build completion
       run: ./.github/scripts/echo_usage.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -140,10 +140,7 @@ jobs:
     # make build emits full_image_name, image_tag, and image_repo outputs
     - name: Build image
       id: build-image
-      with:
-        ACCOUNT_NAME: ${{ secrets.BRYAN_SA_NAME }}
-        SRC_ACCOUNT_KEY: ${{ secrets.BRYAN_SA_KEY }}
-      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} 
+      run: make build/${{ matrix.notebook }} REPO=${{ env.LOCAL_REPO }} DARGS="--build-arg ACCOUNT_NAME=${{ secrets.BRYAN_SA_NAME }} --build-arg SRC_ACCOUNT_KEY=${{ secrets.BRYAN_SA_KEY }}"
 
     - name: Echo disk usage after build completion
       run: ./.github/scripts/echo_usage.sh

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -63,6 +63,8 @@ jobs:
       LOCAL_REPO: localhost:5000
       TRIVY_VERSION: "v0.31.3"
       HADOLINT_VERSION: "2.12.0"
+      ACCOUNT_NAME: ${{ secrets.BRYAN_SA_NAME }}
+      SRC_ACCOUNT_KEY: ${{ secrets.BRYAN_SA_KEY }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -19,6 +19,7 @@
 #     c. AZURE_CREDENTIALS with the output of `az ad sp create-for-rbac --sdk-auth`
 #     d. DEV_REGISTRY_USERNAME with the DEV ACR username
 #     e. DEV_REGISTRY_PASSWORD with the DEV ACR Password
+# test
 #
 # 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below in build-push).
 name: build_and_push

--- a/docker-bits/0_cpu_sas.Dockerfile
+++ b/docker-bits/0_cpu_sas.Dockerfile
@@ -5,7 +5,6 @@
 
 ARG BASE_VERSION=2023-12-25
 
-FROM k8scc01covidacr.azurecr.io/sas4c:0.0.3 as SASHome
 FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root

--- a/docker-bits/4_CLI.Dockerfile
+++ b/docker-bits/4_CLI.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -59,7 +59,7 @@ RUN pip install --no-cache-dir --quiet \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy==4.1.2' \
+    'jupyter-server-proxy==4.2.0' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/docker-bits/6_jupyterlab.Dockerfile
+++ b/docker-bits/6_jupyterlab.Dockerfile
@@ -48,7 +48,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir --quiet \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -21,6 +21,9 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
+ARG ACCOUNT_NAME=${ACCOUNT_NAME}
+ARG SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
+
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \
     mv /tmp/linux_amd64/blobporter /usr/local/bin/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -21,12 +21,6 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
-ENV ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
-
-ARG SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
-ENV SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
-
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \
     mv /tmp/linux_amd64/blobporter /usr/local/bin/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -24,8 +24,8 @@ RUN groupadd -g 1337 supergroup && \
 ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
-ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
+ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
+ENV SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -25,7 +25,7 @@ ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
 ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
+ENV SRC_ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -21,10 +21,10 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG AZURE_ACCOUNT_NAME=${storage_account_name}
+ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
-ARG AZURE_ACCOUNT_KEY=${storage_account_key}
+ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
 ENV ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -21,11 +21,11 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
-ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
+ARG ACCOUNT_NAME=${BRYAN_SA_NAME}
+ENV ACCOUNT_NAME=${BRYAN_SA_NAME}
 
 ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
+ENV SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -21,11 +21,11 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG ACCOUNT_NAME=${BRYAN_SA_NAME}
-ENV ACCOUNT_NAME=${BRYAN_SA_NAME}
+ARG ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
+ENV ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
 
-ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
+ARG SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
+ENV SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -57,9 +57,7 @@ EXPOSE 8561 8591 38080
 
 # SASPY
 
-ENV SASPY_VERSION="5.4.0"
-
-RUN pip install --no-cache-dir --quiet sas_kernel
+RUN mamba install sas_kernel saspy
 
 # TODO: make Python version ENV var.
 COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -59,7 +59,7 @@ EXPOSE 8561 8591 38080
 
 ENV SASPY_VERSION="5.4.0"
 
-RUN pip install sas_kernel
+RUN pip install --no-cache-dir --quiet sas_kernel
 
 # TODO: make Python version ENV var.
 COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py

--- a/docker-bits/6_sas.Dockerfile
+++ b/docker-bits/6_sas.Dockerfile
@@ -4,7 +4,7 @@
 ARG QUARTO_VERSION=1.4.176
 ARG QUARTO_SHA=c06edd8930903a1018a27eb9f70fb9037b28a3cd8a7eb6299e8136876b4e11b3
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
-
+ENV hello="ASD"
 RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz && \
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -212,7 +212,7 @@ RUN pip install --no-cache-dir --quiet \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy==4.1.2' \
+    'jupyter-server-proxy==4.2.0' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/jupyterlab-cpu/Dockerfile
+++ b/output/jupyterlab-cpu/Dockerfile
@@ -201,7 +201,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir --quiet \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -234,7 +234,7 @@ RUN pip install --no-cache-dir --quiet \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy==4.1.2' \
+    'jupyter-server-proxy==4.2.0' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -223,7 +223,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir --quiet \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \

--- a/output/jupyterlab-pytorch/Dockerfile
+++ b/output/jupyterlab-pytorch/Dockerfile
@@ -88,6 +88,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -341,7 +341,7 @@ RUN pip install --no-cache-dir --quiet \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy==4.1.2' \
+    'jupyter-server-proxy==4.2.0' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -330,7 +330,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir --quiet \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \

--- a/output/jupyterlab-tensorflow/Dockerfile
+++ b/output/jupyterlab-tensorflow/Dockerfile
@@ -195,6 +195,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/remote-desktop/Dockerfile
+++ b/output/remote-desktop/Dockerfile
@@ -141,6 +141,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/rstudio/Dockerfile
+++ b/output/rstudio/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -383,12 +383,6 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
-ENV ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
-
-ARG SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
-ENV SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
-
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \
     mv /tmp/linux_amd64/blobporter /usr/local/bin/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update && \
       'byobu' \
       'htop' \
       'jq' \
+      'libsqlite3-dev' \
       'openssl' \
       'ranger' \
       'tig' \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -212,7 +212,7 @@ RUN pip install --no-cache-dir --quiet \
     'markupsafe' \
     'ipympl' \
     'pexpect==4.9.0' \
-    'jupyter-server-proxy==4.1.2' \
+    'jupyter-server-proxy==4.2.0' \
     'jupyterlab-language-pack-fr-fr' \
     'jupyterlab_execute_time' \
     'nb_conda_kernels' \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -383,11 +383,11 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG ACCOUNT_NAME=${BRYAN_SA_NAME}
-ENV ACCOUNT_NAME=${BRYAN_SA_NAME}
+ARG ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
+ENV ACCOUNT_NAME=${{secrets.BRYAN_SA_NAME}}
 
-ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
+ARG SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
+ENV SRC_ACCOUNT_KEY=${{secrets.BRYAN_SA_KEY}}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -10,7 +10,6 @@
 
 ARG BASE_VERSION=2023-12-25
 
-FROM k8scc01covidacr.azurecr.io/sas4c:0.0.3 as SASHome
 FROM quay.io/jupyter/datascience-notebook:$BASE_VERSION
 
 USER root
@@ -378,20 +377,36 @@ RUN groupadd -g 1337 supergroup && \
     useradd -m sas && \
     usermod -a -G supergroup sas && \
     groupadd -g 1002 sasstaff && \
+    usermod -a -G sasstaff jovyan && \
     usermod -a -G sasstaff sas && \
     echo "sas:sas" | chpasswd
 
-COPY --from=SASHome /usr/local/SASHome /usr/local/SASHome
+# BlobPorter
 
-COPY --from=minio/mc:RELEASE.2022-03-17T20-25-06Z /bin/mc /usr/local/bin/mc-original
+ARG AZURE_ACCOUNT_NAME=${storage_account_name}
+ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
+
+ARG AZURE_ACCOUNT_KEY=${storage_account_key}
+ENV ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
+
+RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
+    tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \
+    mv /tmp/linux_amd64/blobporter /usr/local/bin/blobporter && \
+    rm -rf /tmp/* && \
+    chmod a+x /usr/local/bin/blobporter
+
+RUN cd /usr/local/ && \
+    blobporter -f https://bryantestsas.blob.core.windows.net/sasblobcontainer/SASHome.tar.gz -c sasblobcontainer -n SASHome.tar.gz -t blob-file && \
+    tar -xzpf SASHome.tar.gz && \
+    rm SASHome.tar.gz && \
+    chown -R sas:sasstaff /usr/local/SASHome && \
+    ln -s /usr/local/SASHome/SASFoundation/9.4/bin/sas_en /usr/local/bin/sas
+
+COPY --from=minio/mc:RELEASE.2022-03-17T20-25-06Z /bin/mc /usr/local/bin/mc
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*
-
-RUN ln -s /usr/local/SASHome/SASFoundation/9.4/bin/sas_en /usr/local/bin/sas && \
-    usermod -a -G sasstaff jovyan && \
-    chmod -R 0775 /usr/local/SASHome/studioconfig
 
 WORKDIR /home/sas
 
@@ -434,6 +449,7 @@ COPY G-CONFID107003ELNX6494M7/ /usr/local/SASHome/gensys/G-CONFID107003ELNX6494M
 COPY sasv9_local.cfg /usr/local/SASHome/SASFoundation/9.4/
 
 # Enable X command on SAS Studio
+
 COPY spawner_usermods.sh /usr/local/SASHome/studioconfig/spawner/
 
 ###############################

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -383,11 +383,11 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
-ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
+ARG ACCOUNT_NAME=${BRYAN_SA_NAME}
+ENV ACCOUNT_NAME=${BRYAN_SA_NAME}
 
 ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
+ENV SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -419,9 +419,7 @@ EXPOSE 8561 8591 38080
 
 # SASPY
 
-ENV SASPY_VERSION="5.4.0"
-
-RUN pip install --no-cache-dir --quiet sas_kernel
+RUN mamba install sas_kernel saspy
 
 # TODO: make Python version ENV var.
 COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -201,7 +201,7 @@ COPY vscode-overrides.json $CS_TEMP_HOME/Machine/settings.json
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 COPY languagepacks.json $CS_TEMP_HOME/
 
-RUN pip install \
+RUN pip install --no-cache-dir --quiet \
     'git+https://github.com/betatim/vscode-binder' && \
     # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
@@ -421,7 +421,7 @@ EXPOSE 8561 8591 38080
 
 ENV SASPY_VERSION="5.4.0"
 
-RUN pip install sas_kernel
+RUN pip install --no-cache-dir --quiet sas_kernel
 
 # TODO: make Python version ENV var.
 COPY sascfg.py /opt/conda/lib/python3.11/site-packages/saspy/sascfg.py

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -386,8 +386,8 @@ RUN groupadd -g 1337 supergroup && \
 ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
-ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV SRC_ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
+ARG SRC_ACCOUNT_KEY=${BRYAN_SA_KEY}
+ENV SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -383,10 +383,10 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
-ARG AZURE_ACCOUNT_NAME=${storage_account_name}
+ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
-ARG AZURE_ACCOUNT_KEY=${storage_account_key}
+ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
 ENV ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -387,7 +387,7 @@ ARG AZURE_ACCOUNT_NAME=${BRYAN_SA_NAME}
 ENV ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 
 ARG AZURE_ACCOUNT_KEY=${BRYAN_SA_KEY}
-ENV ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
+ENV SRC_ACCOUNT_KEY=${AZURE_ACCOUNT_KEY}
 
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -383,6 +383,9 @@ RUN groupadd -g 1337 supergroup && \
 
 # BlobPorter
 
+ARG ACCOUNT_NAME=${ACCOUNT_NAME}
+ARG SRC_ACCOUNT_KEY=${SRC_ACCOUNT_KEY}
+
 RUN curl -L https://github.com/Azure/blobporter/releases/download/v0.6.20/bp_linux.tar.gz -o /tmp/blobporter.tar.gz && \
     tar -xf /tmp/blobporter.tar.gz -C /tmp linux_amd64/blobporter && \
     mv /tmp/linux_amd64/blobporter /usr/local/bin/blobporter && \

--- a/output/sas/Dockerfile
+++ b/output/sas/Dockerfile
@@ -367,7 +367,7 @@ ENV GIT_EXAMPLE_NOTEBOOKS=https://github.com/StatCan/aaw-contrib-r-notebooks.git
 ARG QUARTO_VERSION=1.4.176
 ARG QUARTO_SHA=c06edd8930903a1018a27eb9f70fb9037b28a3cd8a7eb6299e8136876b4e11b3
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
-
+ENV hello="ASD"
 RUN wget -q ${QUARTO_URL} -O /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz && \
     echo "${QUARTO_SHA} /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | sha256sum -c - && \
     tar -xzvf /tmp/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz -C /tmp/ && \


### PR DESCRIPTION
This update is to remove the SAS image's dependency on sas4c, which is the older SAS image using SAS 9.4 M7.

I have uploaded SAS 9.4 M8 to an Azure storage container and moved the relevant logic out of sas4c into the AAW SAS image.

Todo:
- [x] Add secrets for storage account to Github Actions.

Ticket: https://jirab.statcan.ca/browse/BTIS-304