### PR TITLE
fix: tags

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       REGISTRY_NAME: "k8scc01covidacr.azurecr.io"
-      branch-name: "v1"
+      TAG: "v1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
     with:
       image: ${{ matrix.image }}
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.TAG }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/docker-pull-test.yaml
+++ b/.github/workflows/docker-pull-test.yaml
@@ -14,8 +14,8 @@ on:
         description: url of the registry <registy-name>
         required: true
         type: string
-      branch-name:
-        description: The name of the current branch 
+      tag:
+        description: The tag of the image 
         required: true
         type: string
     secrets:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Pull existing image
         id: pull-existing
-        run: make pull/${{ inputs.image }} REPO=${{ inputs.registry-name }} TAG=${{ inputs.branch-name }}
+        run: make pull/${{ inputs.image }} REPO=${{ inputs.registry-name }} TAG=${{ inputs.tag }}
 
       - name: Set Up Python for Test Suite
         uses: actions/setup-python@v4
@@ -96,7 +96,7 @@ jobs:
             trivy image \
               --db-repository ${{ env.TRIVY_DATABASES }} \
               --java-db-repository ${{ env.TRIVY_JAVA_DATABASES }} \
-              ${{ inputs.registry-name }}/${{ inputs.image }}:${{ inputs.branch-name }} \
+              ${{ inputs.registry-name }}/${{ inputs.image }}:${{ inputs.tag }} \
               --exit-code 10 --timeout=20m --scanners vuln --severity CRITICAL --quiet
             EXIT_CODE=$?
 

--- a/.github/workflows/docker-pull-test.yaml
+++ b/.github/workflows/docker-pull-test.yaml
@@ -72,7 +72,7 @@ jobs:
           make install-python-dev-venv
 
       - name: Test image
-        run: make test/${{ inputs.image }}
+        run: make test/${{ inputs.image }} TAG=${{ inputs.tag }}
 
       # Free up space from build process (containerscan action will run out of space if we don't)
       - name: cleanup runner

--- a/.github/workflows/docker-pull-upload.yaml
+++ b/.github/workflows/docker-pull-upload.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Pull existing image
         id: pull-existing
-        run: make pull/${{ inputs.image }} REPO=${{ inputs.registry-name }} TAG=master
+        run: make pull/${{ inputs.image }} REPO=${{ inputs.registry-name }} TAG=v1
 
       - name: Retag existing image
         run: make post-build/${{ inputs.image }} REPO=${{ inputs.registry-name }} SOURCE_FULL_IMAGE_NAME=${{ steps.pull-existing.outputs.image_name }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -204,7 +204,7 @@ jobs:
     with:
       image: "jupyterlab-cpu"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.branch-name }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -216,7 +216,7 @@ jobs:
     with:
       image: "jupyterlab-tensorflow"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.branch-name }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -228,7 +228,7 @@ jobs:
     with:
       image: "rstudio"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.branch-name }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -240,7 +240,7 @@ jobs:
     with:
       image: "sas"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.branch-name }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -252,7 +252,7 @@ jobs:
     with:
       image: "remote-desktop"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
-      branch-name: "${{ needs.vars.outputs.branch-name }}"
+      tag: "${{ needs.vars.outputs.branch-name }}"
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Tests are formatted using typical pytest formats (python files with `def test_SO
 ```
 username@hostname:~$ docker images
 REPOSITORY                                         TAG            IMAGE ID       CREATED          SIZE
-k8scc01covidacr.azurecr.io/jupyterlab-tensorflow   master         13f8dc0e4f7a   26 minutes ago   14.6GB
-k8scc01covidacr.azurecr.io/jupyterlab-pytorch      master         2b9acb795079   19 hours ago     15.5GB
+k8scc01covidacr.azurecr.io/jupyterlab-tensorflow   v1             13f8dc0e4f7a   26 minutes ago   14.6GB
+k8scc01covidacr.azurecr.io/jupyterlab-pytorch      v1             2b9acb795079   19 hours ago     15.5GB
 jupyter/datascience-notebook                       9ed3b8de5de1   9a0c8d86de1a   5 weeks ago      4.25GB
 ```
 


### PR DESCRIPTION
Some places are using branch name as tag. This is unreliable for master as it is the same as The Zone. 
We must use `v1` when referencing the master branch for AAW. (and `v2` for The Zone. )

changed the variable `branch-name` to `tag` for testing, where it better describes the process. 