### PR TITLE
Remove nbextensions

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -183,10 +183,8 @@ COPY languagepacks.json $CS_TEMP_HOME/
 
 RUN pip install --no-cache-dir \
     'git+https://github.com/betatim/vscode-binder' && \
-    # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
     'nodejs' \
-    'jupyter_contrib_nbextensions' \ 
     'dash' \
     'plotly' \
     'ipywidgets' \
@@ -200,7 +198,6 @@ RUN pip install --no-cache-dir \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \
     jupyter server extension enable --py jupyter_server_proxy && \
-    jupyter nbextension enable codefolding/main --sys-prefix && \
     jupyter labextension enable \
       '@jupyterlab/translation-extension' \
       '@jupyterlab/server-proxy' \

--- a/images/base/jupyterlab-overrides.json
+++ b/images/base/jupyterlab-overrides.json
@@ -1,5 +1,10 @@
 {
     "@jupyterlab/notebook-extension:tracker" : {
-        "recordTiming": true
+        "recordTiming": true,
+        "codeCellConfig": {
+            "codeFolding": true,
+            "lineNumbers": false,
+            "lineWrap": false
+        }
     }
 }

--- a/images/sas/Dockerfile
+++ b/images/sas/Dockerfile
@@ -42,12 +42,6 @@ RUN PYTHON_VERSION=$(python3 -c "import sys; print(f'python{sys.version_info.maj
     && cp /tmp/sascfg.py /opt/conda/lib/$PYTHON_VERSION/site-packages/saspy/sascfg.py \
     && rm /tmp/sascfg.py
 
-RUN jupyter nbextension install --py sas_kernel.showSASLog && \
-    jupyter nbextension enable sas_kernel.showSASLog --py && \
-    jupyter nbextension install --py sas_kernel.theme && \
-    jupyter nbextension enable sas_kernel.theme --py && \
-    jupyter nbextension list
-
 # Jupyter SASStudio Proxy
 
 COPY jupyter-sasstudio-proxy/ /opt/jupyter-sasstudio-proxy/


### PR DESCRIPTION
# Description

Removal of the `nbextensions` 
This extension only effects `Jupyter Notebooks` not `Jupyterlab`'s notebooks. 

Enables the built in code folding setting. 

See: https://github.com/StatCan/aaw/issues/2032
for the full break down of the investigation and changes. 

## Notes

The removal of the `nbextensions` changes the version dependencies, and so a higher version of `notebook` in installed
~~6.5.7~~ -> 7.3.2

An extra extension is listed in the left side bar
`jupyter-notebook-lab-extension`