### PR TITLE
Fix packages flagged by trivy aaw

### DIFF
--- a/.github/workflows/docker-pull-test.yaml
+++ b/.github/workflows/docker-pull-test.yaml
@@ -38,7 +38,7 @@ jobs:
         ports:
           - 5000:5000
     env:
-      TRIVY_VERSION: "0.58.2"
+      TRIVY_VERSION: "0.62.0"
       TRIVY_DATABASES: '"ghcr.io/aquasecurity/trivy-db:2","public.ecr.aws/aquasecurity/trivy-db"'
       TRIVY_JAVA_DATABASES: '"ghcr.io/aquasecurity/trivy-java-db:1","public.ecr.aws/aquasecurity/trivy-java-db"'
       TRIVY_MAX_RETRIES: 5

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
     with:
       image: "base"
       directory: "base"
-      base-image: "quay.io/jupyter/datascience-notebook:2025-02-18"
+      base-image: "quay.io/jupyter/datascience-notebook:2025-04-30"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
       branch-name: "${{ needs.vars.outputs.branch-name }}"
     secrets:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
     with:
       image: "base"
       directory: "base"
-      base-image: "quay.io/jupyter/datascience-notebook:2025-04-30"
+      base-image: "quay.io/jupyter/datascience-notebook:2025-02-18"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
       branch-name: "${{ needs.vars.outputs.branch-name }}"
     secrets:

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,5 +1,6 @@
 USER root
 
+
 ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 
 COPY clean-layer.sh /usr/bin/clean-layer.sh

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -234,8 +234,8 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 
 # OpenM install
 # Install OpenM++ MPI
-ENV OMPP_VERSION="1.17.1"
-ENV OMPP_PKG_DATE="20240322"
+ENV OMPP_VERSION="1.17.8"
+ENV OMPP_PKG_DATE="20250330"
 # Sha needs to be manually generated.
 ARG SHA256ompp=04fc24ad2ed6d6ef1e29430885b77c766eba85e7c5e69ba4c11acb838d712609
 # OpenM++ environment settings

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,6 +1,5 @@
 USER root
 
-
 ENV PATH="/home/jovyan/.local/bin/:${PATH}"
 
 COPY clean-layer.sh /usr/bin/clean-layer.sh

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -237,7 +237,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' && \
 ENV OMPP_VERSION="1.17.8"
 ENV OMPP_PKG_DATE="20250330"
 # Sha needs to be manually generated.
-ARG SHA256ompp=04fc24ad2ed6d6ef1e29430885b77c766eba85e7c5e69ba4c11acb838d712609
+ARG SHA256ompp=3407def2d633e7989396b6e2f2a75a7c445b5fc699d714e846ee8e279ff43b0e
 # OpenM++ environment settings
 ENV OMPP_INSTALL_DIR=/opt/openmpp/${OMPP_VERSION}
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -256,8 +256,8 @@ RUN apt-get update --yes \
     && rm -f /tmp/ompp.tar.gz \
 # Customize and rebuild omp-ui for jupyter-ompp-proxy install
 # issue with making a relative publicPath https://github.com/quasarframework/quasar/issues/8513
-    && sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
-    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.conf.js \
+    && sed -i -e 's/history/hash/' ${OMPP_INSTALL_DIR}/ompp-ui/quasar.config.js \
+    && sed -i -e "s/OMS_URL:.*''/OMS_URL: '.'/" ${OMPP_INSTALL_DIR}/ompp-ui/quasar.config.js \
     && npm install --prefix ${OMPP_INSTALL_DIR}/ompp-ui @babel/traverse@7.23.2\
     && npm run build --prefix ${OMPP_INSTALL_DIR}/ompp-ui \
     && rm -r ${OMPP_INSTALL_DIR}/html \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -65,7 +65,7 @@ ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 
-ENV QUARTO_VERSION=1.5.57
+ENV QUARTO_VERSION=1.7.29
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 ARG QUARTO_CHECKSUM_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-checksums.txt
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -61,7 +61,7 @@ ARG OH_MY_ZSH_SHA=22811faf34455a5aeaba6f6b36f2c79a0a454a74c8b4ea9c0760d1b2d7022b
 ARG TRINO_URL=https://repo1.maven.org/maven2/io/trino/trino-cli/410/trino-cli-410-executable.jar
 ARG TRINO_SHA=f32c257b9cfc38e15e8c0b01292ae1f11bda2b23b5ce1b75332e108ca7bf2e9b
 
-ARG ARGO_CLI_VERSION=v3.5.14
+ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -65,7 +65,7 @@ ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 
-ENV QUARTO_VERSION=1.7.29
+ENV QUARTO_VERSION=1.8.1
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 ARG QUARTO_CHECKSUM_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-checksums.txt
 

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -485,7 +485,7 @@ ENV OMPP_VERSION="1.17.8"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20250330"
 # Sha needs to be manually generated.
-ARG SHA256ompp=76c16dd8e2ca637006b92c4cc36541cedc776dda1a06fcf0702859271ca78ac3
+ARG SHA256ompp=3407def2d633e7989396b6e2f2a75a7c445b5fc699d714e846ee8e279ff43b0e
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -481,9 +481,9 @@ COPY minio-icon.png $RESOURCES_PATH/minio-icon.png
 COPY remote-desktop/minio-launch.py /usr/bin/minio-launch.py
 
 # Install OpenM++
-ENV OMPP_VERSION="1.17.1"
+ENV OMPP_VERSION="1.17.8"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
-ENV OMPP_PKG_DATE="20240322"
+ENV OMPP_PKG_DATE="20250330"
 # Sha needs to be manually generated.
 ARG SHA256ompp=76c16dd8e2ca637006b92c4cc36541cedc776dda1a06fcf0702859271ca78ac3
 # OpenM++ environment settings

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -117,7 +117,7 @@ ARG OH_MY_ZSH_SHA=22811faf34455a5aeaba6f6b36f2c79a0a454a74c8b4ea9c0760d1b2d7022b
 ARG TRINO_URL=https://repo1.maven.org/maven2/io/trino/trino-cli/410/trino-cli-410-executable.jar
 ARG TRINO_SHA=f32c257b9cfc38e15e8c0b01292ae1f11bda2b23b5ce1b75332e108ca7bf2e9b
 
-ARG ARGO_CLI_VERSION=v3.5.14
+ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -498,7 +498,7 @@ RUN apt-get update --yes \
     && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
     && mkdir /opt/openmpp \
-    && mv /tmp/openmpp_debian-11_${OMPP_PKG_DATE} /opt/openmpp/${OMPP_VERSION} \
+    && mv /tmp/openmpp_debian_${OMPP_PKG_DATE} /opt/openmpp/${OMPP_VERSION} \
     && chown -R $NB_UID:$NB_GID /opt/openmpp
 # Copy the desktop icon into place for the web UI
 COPY openmpp.png $RESOURCES_PATH/openmpp.png

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -121,7 +121,7 @@ ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 
-ENV QUARTO_VERSION=1.5.57
+ENV QUARTO_VERSION=1.7.29
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 ARG QUARTO_CHECKSUM_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-checksums.txt
 

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -485,7 +485,7 @@ ENV OMPP_VERSION="1.17.8"
 # IMPORTANT: Don't forget to update the version number in the openmpp.desktop file!!
 ENV OMPP_PKG_DATE="20250330"
 # Sha needs to be manually generated.
-ARG SHA256ompp=3407def2d633e7989396b6e2f2a75a7c445b5fc699d714e846ee8e279ff43b0e
+ARG SHA256ompp=83b640bfe8fa088bd029015628a39816fb30e3e46192e0dfa18db91094489000
 # OpenM++ environment settings
 ENV OMPP_USER=$NB_USER
 ENV OMPP_GROUP=100
@@ -494,7 +494,7 @@ ENV OMPP_GID=$NB_GID
 # OpenM++ expects sqlite to be installed (not just libsqlite)
 RUN apt-get update --yes \
     && apt-get install --yes sqlite3 \
-    && wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian-11_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
+    && wget https://github.com/openmpp/main/releases/download/v${OMPP_VERSION}/openmpp_debian_${OMPP_PKG_DATE}.tar.gz -O /tmp/ompp.tar.gz \
     && echo "${SHA256ompp} /tmp/ompp.tar.gz" | sha256sum -c - \
     && tar -xf /tmp/ompp.tar.gz -C /tmp/ \
     && mkdir /opt/openmpp \

--- a/images/remote-desktop/Dockerfile
+++ b/images/remote-desktop/Dockerfile
@@ -121,7 +121,7 @@ ARG ARGO_CLI_VERSION=v3.6.7
 ARG ARGO_CLI_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-linux-amd64.gz
 ARG ARGO_CLI_CHECKSUM_URL=https://github.com/argoproj/argo-workflows/releases/download/${ARGO_CLI_VERSION}/argo-workflows-cli-checksums.txt
 
-ENV QUARTO_VERSION=1.7.29
+ENV QUARTO_VERSION=1.8.1
 ARG QUARTO_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz
 ARG QUARTO_CHECKSUM_URL=https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-checksums.txt
 

--- a/images/remote-desktop/desktop-files/openmpp.desktop
+++ b/images/remote-desktop/desktop-files/openmpp.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=OpenM++
-Exec=/opt/openmpp/1.17.1/bin/ompp_ui_linux.sh
+Exec=/opt/openmpp/1.17.8/bin/ompp_ui_linux.sh
 Icon=/resources/openmpp.png
 Terminal=false
 Categories=Development;


### PR DESCRIPTION
Updates the package version of some packages flagged by Trivy
Linked to https://github.com/StatCan/aaw-kubeflow-containers/issues/734

* arco-cli
* quarto
* OpenM++